### PR TITLE
docs: comprehensive v0.9.1 documentation audit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Copilot Instructions for Cyber Survivor
 
 ## Project Overview
-Python + Pygame top-down hack-and-slash survival game. ~12,742 LOC across 43 Python files. Procedural graphics and audio (zero external assets). Title: **"Cyber Survivor"**.
+Python + Pygame top-down hack-and-slash survival game. ~14,000 LOC across 46 Python files. Procedural graphics and audio (zero external assets). Title: **"Cyber Survivor"**. Current version: `0.9.1` (Early Access).
 
 ## Architecture
 - Entry: `main.py` → `src/game.py` Game class
@@ -35,7 +35,9 @@ Python + Pygame top-down hack-and-slash survival game. ~12,742 LOC across 43 Pyt
 | `src/ui/toast.py` | Slide-in achievement-style toast notifications |
 | `src/ui/compendium_screen.py` | Compendium browser with procedural monster art + inspect view |
 | `src/ui/hud.py` | In-game HUD (HP/XP bars, boss HP, wave info, coin count, vignette) |
-| `src/ui/charselect.py` | 3-class picker (knight / archer / jester) |
+| `src/ui/charselect.py` | 3-class picker (knight / ranger / jester) |
+| `src/ui/cursor.py` | Procedural animated crosshair — class-themed, rotates, contracts on click |
+| `src/ui/portal_screen.py` | Between-zone portal menu (Continue / Summary / Compendium) |
 | `src/ui/levelup.py` | Level-up upgrade choices |
 | `src/ui/radar.py` | Motion tracker |
 | `src/ui/legacy_screen.py` | Post-death permanent upgrade shop |
@@ -54,12 +56,13 @@ Python + Pygame top-down hack-and-slash survival game. ~12,742 LOC across 43 Pyt
 - **cyber_rat** — tiny, fast melee, erratic jitter movement
 - **cyber_raccoon** — medium melee, sidestep-dodges when hit
 - **mega_cyber_deer** *(sub-boss, wave 5)* — large charging boss, antler slam special
-- **d_lack** — ranged, shoots cyan bullets (renamed from dalek)
+- **d_lek** — ranged, shoots cyan bullets; parallel beam burst attack
 - **charger** — charges in a straight line
 - **shielder** — has a damage-absorbing shield
 - **spitter** — longer-range acid ranged attacker, kites away from player
+- **emperors_elite_guard** — elite ranged flanking unit
 - **iron_sentinel** *(mini-boss)* — 3-way spread shots, missile_barrage special
-- **warlord_kron** *(big boss)* — 5-way spread shots, bleed_storm special
+- **supreme_d_lek** *(big boss)* — 5-way spread shots, bleed_storm special; D-Lek Emperor visual
 
 ### Zone 2 — City ("Ruined Metropolis")
 - **cyber_zombie** — slow, high HP melee
@@ -67,7 +70,7 @@ Python + Pygame top-down hack-and-slash survival game. ~12,742 LOC across 43 Pyt
 - **drone** — ranged flyer
 - **cultist** — ranged, applies fire on hit
 - **shambler** — slow, large AOE melee
-- **preacher** *(mini-boss)* — 3-way fire spread shots, fire_ring special
+- **street_preacher** *(mini-boss)* — 3-way fire spread shots, fire_ring special
 - **eldritch_horror** *(big boss)* — 7-shot fan, eldritch_pull special
 
 ### Zone 3 — Abyss ("The Abyss")
@@ -87,6 +90,14 @@ Python + Pygame top-down hack-and-slash survival game. ~12,742 LOC across 43 Pyt
 - Call `sounds.start_boss_music(zone)` on boss spawn, `sounds.stop_boss_music()` on boss death
 - Boss music is cached to `.cache/boss_music_v1.pkl`, keyed by zone name
 
+## Super Skill System
+- `player.energy` (0–100) fills at +10/kill, +40/boss kill
+- Right-click fires super when energy == max_energy; energy resets to 0
+- **Ranger**: EMP Arrow — `spawn_grenades()` with speed=18, splash_radius=150, damage×15
+- **Knight**: Blade Storm Nova — 12 `ThrownDagger` instances at 30° intervals, 360°
+- **Jester**: Chaos Eruption — 6 `ConfettiGrenade` instances at 60° intervals
+- Implemented in `game.py` `_fire_super_skill()`
+
 ## Conventions
 - All graphics are drawn with `pygame.draw.*` — no image files
 - All audio is generated with `pygame.sndarray` — no sound files
@@ -97,8 +108,13 @@ Python + Pygame top-down hack-and-slash survival game. ~12,742 LOC across 43 Pyt
 - XP drops as collectible pickup orbs (green, 12s lifetime) — handled by `pickups.py`
 - Zone constants live in `zones.py`: `ZONE_ORDER = ["wasteland", "city", "abyss"]`
 - When adding a passive: define in upgrade pool (boss_chest.py or levelup.py), then implement the check in game.py `_update()`, player.py, or combat.py
+- Grenade explosion tuples are **4-tuples**: `(x, y, damage, splash_radius)` — always unpack all four
+- `VERSION` string lives in `src/settings.py` — bump it there and it propagates to main menu watermark and build script
+- Portal menu uses a **frozen screenshot** as background; captured via `self._draw()` + `screen.copy()` at `portal_menu.activate()` time
+- Class name for Archer/Ranger is `"archer"` in code (char_class value) but displayed as **Ranger** in all UI
 
 ## Testing
-- Quick compile check: `python -c "from src.game import Game; print('OK')"`
+- Quick compile + version check: `python -c "from src.game import Game; from src.settings import VERSION; print(f'OK - v{VERSION}')"` 
 - Run game: `python main.py`
+- Build Windows release: `.\build_release.ps1`
 - No test framework — verify by running the game

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ You'll see `(.venv)` in your terminal prompt when it's active.
 pip install -r requirements.txt
 ```
 
-This installs **Pygame**, the only dependency.
+This installs **Pygame** and **NumPy** (required for procedural audio generation).
 
 ### 5. Run the game
 
@@ -81,28 +81,49 @@ hacknslash/
 │   ├── settings.py          # All tunable constants (speeds, HP, sizes, colors)
 │   ├── game.py              # Main loop — ties everything together
 │   ├── entities/            # Things in the world
-│   │   ├── player.py        # Player movement, attacks, leveling, 3 character classes
-│   │   └── enemy.py         # Enemy AI, 4 types (Dalek, Wraith, Mini-Boss, Big Boss)
+│   │   ├── player.py        # Player movement, attacks, leveling, 3 classes (knight/ranger/jester)
+│   │   └── enemy.py         # Enemy AI, 21 types across 3 zones
 │   ├── systems/             # Game mechanics
 │   │   ├── combat.py        # Hit detection, damage numbers, XP
 │   │   ├── spawner.py       # Wave spawning, patterns, boss waves, difficulty scaling
 │   │   ├── projectiles.py   # Enemy bullets + player daggers, orbiters, grenades
-│   │   ├── weapons.py       # 16+ weapons across 3 classes, drawing & stats
+│   │   ├── weapons.py       # 18+ weapons across 3 classes, drawing & stats
 │   │   ├── pickups.py       # Item drops (heal, stat boosts, apples)
 │   │   ├── boss_chest.py    # Boss chest drops and reward selection screen
+│   │   ├── compendium.py    # Enemy unlock tracking — first-kill logic, JSON save
+│   │   ├── game_actions.py  # Enemy death processing, coin drops, projectile helpers
 │   │   ├── environment.py   # Trees, rocks, bushes, fruit trees
 │   │   ├── campfire.py      # Healing campfire between waves
 │   │   ├── lighting.py      # Dynamic darkness overlay and light sources
 │   │   ├── animations.py    # Particles, death bursts, screen shake
-│   │   ├── sounds.py        # Procedurally generated SFX and 8-bit music
+│   │   ├── sounds.py        # Procedurally generated SFX + 2-layer chiptune + boss music
 │   │   ├── status_effects.py# Fire, bleed, poison, slow effects
 │   │   ├── camera.py        # Smooth-follow camera
-│   │   └── game_map.py      # Tile-based world grid
+│   │   ├── game_map.py      # Tile-based world grid
+│   │   ├── zones.py         # Zone definitions (wasteland / city / abyss)
+│   │   ├── atmosphere.py    # Atmospheric visual effects per zone
+│   │   ├── hazards.py       # Zone-specific hazards (acid, storms, void rifts)
+│   │   ├── portal.py        # Zone transition portal entity
+│   │   ├── legacy.py        # Roguelite persistence (JSON save)
+│   │   └── run_stats.py     # Per-run statistics tracking
 │   └── ui/                  # User interface
 │       ├── hud.py           # HP/XP bars, wave info, boss HP bar, danger vignette
 │       ├── radar.py         # AVP-style motion tracker
 │       ├── levelup.py       # Level-up upgrade selection
-│       └── charselect.py    # Character class picker
+│       ├── charselect.py    # Character class picker
+│       ├── cursor.py        # Animated procedural crosshair — class-themed
+│       ├── main_menu.py     # Main menu + settings
+│       ├── portal_screen.py # Between-zone portal menu (Continue/Summary/Compendium)
+│       ├── run_summary.py   # Post-run statistics summary screen
+│       ├── compendium_screen.py # Compendium browser with procedural monster art
+│       ├── legacy_screen.py # Post-death permanent upgrade shop
+│       ├── passive_swap.py  # Passive swap screen when all slots are full
+│       ├── toast.py         # Slide-in achievement-style toast notifications
+│       ├── tooltip.py       # Weapon/passive info tooltips
+│       ├── weapon_swap.py   # Weapon swap selection screen
+│       ├── icons.py         # 35 procedural icon drawings
+│       ├── debug_menu.py    # Developer debug menu
+│       └── debug_overlay.py # In-game debug overlay (F3)
 └── assets/                  # Empty placeholder folders (all art/sound is procedural)
 ```
 
@@ -150,6 +171,12 @@ Here's where to edit based on what you're doing:
 | Add a new passive ability | `src/systems/boss_chest.py` or `src/ui/levelup.py` (define) + `src/game.py` or `src/systems/game_actions.py` (implement) |
 | Add a roguelite upgrade | `src/systems/legacy.py` + `src/ui/legacy_screen.py` |
 | Change how damage/combat works | `src/systems/combat.py` |
+| Add/edit zone definitions | `src/systems/zones.py` |
+| Add zone-specific hazards | `src/systems/hazards.py` |
+| Modify the portal/between-zone menu | `src/ui/portal_screen.py` + `src/systems/portal.py` |
+| Edit run statistics tracking | `src/systems/run_stats.py` + `src/ui/run_summary.py` |
+| Edit the compendium bestiary | `src/systems/compendium.py` + `src/ui/compendium_screen.py` |
+| Change the cursor appearance | `src/ui/cursor.py` |
 
 ### Step 3: Test your changes
 

--- a/GAMEPLAY.md
+++ b/GAMEPLAY.md
@@ -11,6 +11,7 @@ A complete guide to everything in the game — classes, weapons, enemies, mechan
 | Move | W / A / S / D or Arrow Keys |
 | Attack / Confirm | Space, J, E, or Left Mouse Click |
 | Dash | Shift or K |
+| Super Skill | Right Mouse (hold → release, when Energy is full) |
 | Pause | Esc or P |
 | Aim | Move the mouse — your character always faces the cursor |
 | Select chest reward | Number keys 1–5 |
@@ -31,7 +32,7 @@ Heavy armor, devastating melee. Born to fight up close.
   - *Melee Lifesteal* — Recover 5 HP every time you kill an enemy with a melee weapon
   - *Armor Plating* — Take 20% less damage from all sources
 
-### Archer
+### Ranger
 
 Fast and deadly at range. Keep your distance.
 
@@ -63,30 +64,32 @@ Melee weapons swing in an arc in front of you. Wider sweep angles hit more enemi
 |--------|--------|-------|----------|-----------|-------|
 | Sword | 1.0x | 60 | 400ms | 120° | Balanced starter |
 | Battle Axe | 1.6x | 50 | 650ms | 90° | Hard-hitting, narrow |
-| Spear | 1.1x | 90 | 500ms | 40° | Long reach, precise |
+| Spear | 1.3x | 90 | 500ms | 40° | Long reach, precise |
 | War Hammer | 2.2x | 55 | 900ms | 160° | Slow, devastating |
 | Plasma Blade | 1.4x | 65 | 350ms | 130° | Fast and strong |
-| Gravity Maul | 2.8x | 60 | 1000ms | 180° | Highest damage, very slow |
+| Gravity Maul | 3.5x | 60 | 1000ms | 180° | Highest damage, very slow |
 | Rubber Chicken | 0.8x | 55 | 350ms | 140° | Jester starter, fast |
 | Joy Buzzer | 1.3x | 35 | 500ms | 360° | Short range, hits all around you |
 
 Damage shown is a multiplier on your base damage stat.
 
-### Ranged Weapons (Archer)
+### Ranged Weapons (Ranger)
 
 | Weapon | Damage | Cooldown | Projectiles | Speed | Lifetime | Notes |
-|--------|--------|----------|-------------|-------|----------|-------|
+|--------|--------|----------|-------------|-------|----------|—-----|
 | Throwing Dagger | 1.0x | 350ms | 1 | 8.0 | 900ms | Precision single throw |
 | Cyber Bow | 1.8x | 550ms | 1 | 11.0 | 1500ms | **Pierces through enemies** |
-| Pulse Rifle | 0.7x | 150ms | 1 | 10.0 | 700ms | Rapid fire energy bolts |
+| Pulse Rifle | 0.7x | 220ms | 1 | 10.0 | 700ms | Rapid fire energy bolts |
 | Scatter Shot | 0.6x | 600ms | 5 | 7.0 | 600ms | Wide 5-bolt spread |
+| Burst Crossbow | 1.0x | 480ms | 3 | 9.0 | 900ms | 3-bolt burst, slight spread |
+| Explosive Crossbow | 2.0x | 900ms | 1 | 7.5 | 1200ms | Explodes on impact, 50px splash |
 
 ### Ranged Weapons (Jester)
 
 | Weapon | Damage | Cooldown | Type | Notes |
 |--------|--------|----------|------|-------|
 | Banana-Rang | 0.9x | 450ms | Orbiter | Launches out, returns, orbits you (max 3) |
-| Pie Launcher | 1.5x | 700ms | Grenade | Explodes on contact |
+| Pie Launcher | 2.2x | 700ms | Grenade | Explodes on contact |
 | Confetti Grenade | 1.8x | 800ms | Grenade | 60px splash radius, area damage |
 
 ### Orbiting Weapons (Knight: Blade Barrier / Jester: Banana-Rang)
@@ -129,6 +132,28 @@ Key details:
 
 ---
 
+## Super Skills
+
+Every class has a powerful Super Skill triggered with **Right Mouse** (hold to charge, release to fire) when your **Energy bar** is full.
+
+### Energy Bar
+- Displayed horizontally in the HUD (gold/amber bar, above the wave counter)
+- Fills **+10 Energy per kill**, **+40 Energy per boss kill**
+- Resets to 0 after firing your super
+- Maximum energy is 100
+
+### Class Super Skills
+
+| Class | Super Skill | Description |
+|-------|-------------|-------------|
+| Knight | **Blade Storm Nova** | Fires 12 Thrown Daggers simultaneously in a full 360° ring |
+| Ranger | **EMP Arrow** | Launches a high-damage grenade (damage ×15) with a 150px splash radius |
+| Jester | **Chaos Eruption** | Launches 6 Confetti Grenades spread evenly in a 360° ring |
+
+**Tip:** Save your super for boss phase 2 (40% HP threshold) — the extra burst can cut through the enrage window.
+
+---
+
 ## Zones
 
 The game progresses through three distinct zones. You reach the next zone by defeating the zone's big boss and stepping through the portal that appears.
@@ -149,6 +174,18 @@ Zone hazards activate at the listed wave and persist for the rest of that zone.
 
 ---
 
+## Portal Menu
+
+After defeating a zone's big boss, a glowing **portal** appears in the arena. Walk into it to open the between-zone Portal Menu:
+
+- **Continue** — step through the portal and travel to the next zone
+- **Run Summary** — review your current run stats (kills, damage dealt, bosses killed, etc.)
+- **Compendium** — browse the enemy bestiary before pressing on
+
+The portal menu uses a frozen screenshot of the game as its background — no performance cost.
+
+---
+
 ## Enemies
 
 Each zone has 5 regular enemy types and 2 bosses (mini-boss and big boss). Bosses enter **Phase 2** when reduced to 40% HP — see the [Boss Phase 2](#boss-phase-2) section below.
@@ -157,13 +194,16 @@ Each zone has 5 regular enemy types and 2 bosses (mini-boss and big boss). Bosse
 
 | Enemy | Notes |
 |-------|-------|
-| **Dalek** | Ranged — shoots cyan bullets every 1200ms, engages at 320px |
-| **Wraith** | Fast melee — applies **Poison** on hit |
+| **Cyber Rat** | Tiny, fast melee — erratic jitter movement |
+| **Cyber Raccoon** | Medium melee — sidestep-dodges when hit |
+| **Mega Cyber Deer** *(sub-boss, wave 5)* | Large charging sub-boss — antler slam special |
+| **D-Lek** | Ranged — shoots cyan bullets; parallel beam burst attack |
 | **Charger** | Charges in a straight line toward the player |
 | **Shielder** | Has a damage-absorbing shield; break the shield first |
-| **Spitter** | Longer-range acid ranged attacker |
+| **Spitter** | Longer-range acid ranged attacker, kites away from player |
+| **Emperor's Elite Guard** | Elite ranged flanking unit |
 | **Iron Sentinel** *(mini-boss)* | 3-way spread shots, **missile_barrage** special |
-| **Warlord Kron** *(big boss)* | 5-way spread shots, **bleed_storm** special |
+| **Supreme D-Lek** *(big boss)* | 5-way spread shots, **bleed_storm** special; D-Lek Emperor visual |
 
 ### Zone 2 — Ruined Metropolis
 
@@ -174,13 +214,14 @@ Each zone has 5 regular enemy types and 2 bosses (mini-boss and big boss). Bosse
 | **Drone** | Ranged flyer |
 | **Cultist** | Ranged — applies **Fire** on hit |
 | **Shambler** | Slow, large AOE melee swing |
-| **Preacher** *(mini-boss)* | 3-way fire spread shots, **fire_ring** special |
+| **Street Preacher** *(mini-boss)* | 3-way fire spread shots, **fire_ring** special |
 | **Eldritch Horror** *(big boss)* | 7-shot fan spread, **eldritch_pull** special |
 
 ### Zone 3 — The Abyss
 
 | Enemy | Notes |
 |-------|-------|
+| **Specter** | Void-touched wraith melee — applies **Bleed** on hit |
 | **Void Wisp** | Ranged, fast, low HP |
 | **Rift Walker** | Teleports near the player |
 | **Mirror Shade** | Copies your movement direction |
@@ -205,8 +246,8 @@ When any boss reaches **40% HP** it enters an enraged Phase 2:
 | Boss | Phase 2 Special |
 |------|-----------------|
 | Iron Sentinel | missile_barrage — carpet of homing missiles |
-| Warlord Kron | bleed_storm — spreading bleed field |
-| Preacher | fire_ring — expanding ring of fire |
+| Supreme D-Lek | bleed_storm — spreading bleed field |
+| Street Preacher | fire_ring — expanding ring of fire |
 | Eldritch Horror | eldritch_pull — pulls player and enemies together |
 | Architect | void_cage — rings of void bolts |
 | Nexus | reality_collapse — screen-wide reality distortion |
@@ -338,8 +379,6 @@ Killing a boss spawns a glowing chest. Walk into it to open a reward screen with
 ### Weapon Upgrades
 A new weapon appropriate to your class may appear as one of the choices.
 
----
-
 ## Leveling Up
 
 You gain XP from killing enemies. When you level up, you're offered a choice of 3 upgrades filtered to your class. XP requirements increase with each level.
@@ -378,6 +417,22 @@ The heads-up display shows:
 - **Radar** (corner) — shows dots for nearby enemies and the campfire
 - **Status effect icons** — appear on your character when affected
 - **Floating damage numbers** — pop up when you or enemies take hits
+
+---
+
+## Compendium
+
+The **Compendium** is an in-game bestiary that tracks every enemy type you encounter.
+
+- A new entry **unlocks on first kill** — you'll see a toast notification appear
+- Access it from the **Portal Menu** between zones, or from the **Main Menu**
+- Each entry shows:
+  - The enemy's procedurally drawn art
+  - Zone it appears in
+  - Enemy type (melee / ranged / boss)
+  - A brief description
+  - **Inspect view** — larger art and any special abilities
+- There are **21 entries** total, one per enemy type across all three zones
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ python main.py
 | WASD / Arrow Keys | Move |
 | Space / J / E / Left Click | Attack / Confirm |
 | Shift / K | Dash (i-frames) |
+| Right Mouse (hold → release) | Super Skill (when Energy full) |
 | Mouse | Aim direction |
 | Esc / P | Pause menu |
 | 1–5 | Select upgrades |
@@ -25,8 +26,10 @@ python main.py
 
 - **3 Zones** — Wasteland (The Forest), City (Ruined Metropolis), Abyss — each with unique enemies, hazards, and boss music
 - **21 Enemy Types** — 7 per zone including mini-bosses and a big boss with phase-2 enrage
-- **3 Character Classes** — Knight (heavy melee), Archer (fast ranged), Jester (chaotic fun)
-- **16+ Weapons** — swords, axes, throwing daggers, banana boomerangs, confetti grenades, orbiters, and more
+- **3 Character Classes** — Knight (heavy melee), Ranger (fast ranged), Jester (chaotic fun)
+- **Super Skills** — right-click to unleash a class-unique ability when your Energy bar is full (Knight: Blade Storm Nova, Ranger: EMP Arrow, Jester: Chaos Eruption)
+- **Energy Bar** — fills +10 per kill, +40 per boss kill; resets on super use
+- **18+ Weapons** — swords, axes, throwing daggers, banana boomerangs, confetti grenades, burst crossbow, explosive crossbow, orbiters, and more
 - **Boss Phase 2** — at 40% HP bosses enrage: +40% speed, −45% cooldowns, enhanced spread shots, and unique secondary specials
 - **Unique boss music per zone** — procedurally generated and cached on first play
 - **Wave-based combat** with escalating difficulty (+12% HP, +8% damage, +3% speed per wave)
@@ -35,6 +38,9 @@ python main.py
 - **XP pickup orbs** — XP drops as collectible green orbs with a 12-second lifetime
 - **Zone hazards** — acid puddles, dust storms, toxic gas, void rifts, and more
 - **Passive abilities** — lifesteal, chain lightning, vampiric strike, thorns, shield matrix, second wind, explosive kills, and more
+- **Compendium** — in-game bestiary; enemy entries unlock on first kill, with procedural art and inspect view
+- **Portal menu** — between-zone screen to review stats, browse the Compendium, or continue
+- **Animated custom cursor** — class-themed procedural crosshair that rotates and contracts on click
 - **Roguelite persistence** — Legacy Points and 6 permanent upgrades that carry between runs
 - **Dynamic lighting** — darkness scales enemy stats and XP rewards
 - **Procedural audio** — two-layer 8-bit chiptune with calm/combat crossfade and generated SFX
@@ -67,6 +73,7 @@ hacknslash/
     │   ├── weapons.py         # Weapon definitions and drawing
     │   ├── pickups.py         # Item drops: coins, XP orbs, heals
     │   ├── boss_chest.py      # Boss chest rewards
+    │   ├── compendium.py      # Enemy unlock tracking — first-kill logic, JSON save
     │   ├── game_actions.py    # Death processing & projectile firing helpers
     │   ├── legacy.py          # Roguelite persistence (JSON save)
     │   ├── environment.py     # Trees, rocks, fruit trees
@@ -87,10 +94,14 @@ hacknslash/
         ├── radar.py           # Motion tracker
         ├── levelup.py         # Level-up upgrade selection
         ├── charselect.py      # Character class picker
+        ├── cursor.py          # Animated procedural crosshair — class-themed
         ├── legacy_screen.py   # Post-death permanent upgrade shop
         ├── main_menu.py       # Main menu + settings (resolution, fullscreen, music)
+        ├── portal_screen.py   # Between-zone portal menu (Continue / Summary / Compendium)
         ├── run_summary.py     # Post-run statistics summary screen
+        ├── compendium_screen.py # Compendium browser with procedural monster art
         ├── passive_swap.py    # Passive swap screen when all slots are full
+        ├── toast.py           # Slide-in achievement-style toast notifications
         ├── tooltip.py         # Weapon/passive info tooltips
         ├── weapon_swap.py     # Weapon swap selection screen
         ├── icons.py           # 35 procedural icon drawings


### PR DESCRIPTION
Brings all four documentation files fully in sync with the v0.9.1 codebase. No code changes — docs only.

## Files changed

### `README.md`
- Rename Archer → Ranger throughout
- Add Right Mouse / Super Skill to controls table
- Add Super Skills, Energy Bar, Compendium, Portal Menu, and animated cursor to features
- Expand project structure with all new files (`compendium.py`, `compendium_screen.py`, `cursor.py`, `portal_screen.py`, `run_stats.py`, `toast.py`)
- Update weapon count to 18+

### `GAMEPLAY.md`
- All "Archer" references updated to "Ranger"
- Weapon stat corrections: spear `1.1x→1.3x`, gravity_maul `2.8x→3.5x`, pie_launcher `1.5x→2.2x`, pulse_rifle cooldown `150ms→220ms`
- Add `burst_crossbow` and `explosive_crossbow` to Ranger weapon table
- Completely rewrite Zone 1 enemy table (was stale Dalek/Wraith; now all 10 current enemies: cyber_rat, cyber_raccoon, mega_cyber_deer, d_lek, charger, shielder, spitter, emperors_elite_guard, iron_sentinel, supreme_d_lek)
- Fix Zone 2 Preacher → Street Preacher
- Add Specter to Zone 3 enemy table
- Fix boss Phase 2 table: Warlord Kron → Supreme D-Lek
- Add new sections: **Super Skills**, **Portal Menu**, **Compendium**
- Add Right Mouse super skill to controls table

### `CONTRIBUTING.md`
- Fix enemy count: "4 types (Dalek, Wraith...)" → "21 types across 3 zones"
- Update requirements note to mention NumPy
- Expand project structure to reflect all 46 files
- Add rows to edit-guide table: zones, hazards, portal menu, run stats, compendium, cursor

### `.github/copilot-instructions.md`
- Fix `d_lack → d_lek`, `warlord_kron → supreme_d_lek`, `preacher → street_preacher`
- Fix charselect.py row: archer → ranger
- Add `cursor.py` and `portal_screen.py` to file table
- Add Super Skill System section
- Update Conventions: grenade 4-tuple note, VERSION location, portal frozen background, build script
- Update Testing commands