### PR TITLE
fix: PyInstaller exe crash — ModuleNotFoundError: xml

### DIFF
--- a/cyber_survivor.spec
+++ b/cyber_survivor.spec
@@ -34,8 +34,6 @@ a = Analysis(
         'cv2',
         'IPython',
         'jupyter',
-        'setuptools',
-        'xml',
         'xmlrpc',
         'test',
         'unittest',


### PR DESCRIPTION
## Problem
Exe crashes on launch:
```
ModuleNotFoundError: No module named 'xml'
```

## Root Cause
PyInstaller's runtime hook `pyi_rth_pkgres.py` loads `pkg_resources` (from `setuptools`) → which loads `plistlib` → which requires `xml`. Both `setuptools` and `xml` were in the excludes list.

## Fix
Remove `setuptools` and `xml` from PyInstaller excludes. `xmlrpc` remains excluded (not used).