### PR TITLE
fix: exe crash on char select, dev mode persistence, leaderboard secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,20 @@ jobs:
                           out.write(f"value={ver}\n")
                       break
 
+      - name: Inject Supabase secrets
+        if: env.SUPABASE_URL != ''
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        shell: python
+        run: |
+          import os
+          url = os.environ.get('SUPABASE_URL', '')
+          key = os.environ.get('SUPABASE_ANON_KEY', '')
+          with open('src/secrets.py', 'w') as f:
+              f.write(f'SUPABASE_URL = "{url}"\n')
+              f.write(f'SUPABASE_ANON_KEY = "{key}"\n')
+
       - name: Build with PyInstaller
         run: pyinstaller cyber_survivor.spec --clean --noconfirm
 

--- a/src/systems/sounds.py
+++ b/src/systems/sounds.py
@@ -104,6 +104,8 @@ class SoundManager:
 
     def stop_boss_music(self):
         """Stop boss music and restore zone music."""
+        if not hasattr(self, '_boss_channel'):
+            return
         self._boss_channel.stop()
         self.boss_music_playing = False
         # Restore zone BGM

--- a/src/ui/main_menu.py
+++ b/src/ui/main_menu.py
@@ -28,6 +28,8 @@ def load_settings() -> dict:
             data = json.load(f)
         # Merge with defaults for any missing keys
         merged = {**DEFAULT_SETTINGS, **data}
+        # dev_options should never persist — always require manual activation
+        merged["dev_options"] = False
         return merged
     except (FileNotFoundError, json.JSONDecodeError):
         return dict(DEFAULT_SETTINGS)


### PR DESCRIPTION
## Fixes

### 1. `AttributeError: 'SoundManager' object has no attribute '_boss_channel'`
`stop_boss_music()` was called during `_init_world()` before any boss music had been started, so `_boss_channel` didn't exist yet. Added a `hasattr` guard.

### 2. Dev mode persisting across sessions
`dev_options` was saved to the settings JSON file. Now `load_settings()` always resets it to `False` so users must manually re-enable it each session (via the konami-style activation).

### 3. Leaderboard shows "not configured"
`src/secrets.py` (contains `SUPABASE_URL` and `SUPABASE_ANON_KEY`) is gitignored and never bundled in the exe. Added a CI step that writes `src/secrets.py` from GitHub Actions secrets before the PyInstaller build.

**Note**: You need to add two repository secrets in GitHub Settings:
- `SUPABASE_URL`
- `SUPABASE_ANON_KEY`