### PR TITLE
fix: CI secrets injection — broken condition + unsafe string interpolation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,18 +59,21 @@ jobs:
                       break
 
       - name: Inject Supabase secrets
-        if: env.SUPABASE_URL != ''
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
         shell: python
         run: |
-          import os
+          import os, json
           url = os.environ.get('SUPABASE_URL', '')
           key = os.environ.get('SUPABASE_ANON_KEY', '')
-          with open('src/secrets.py', 'w') as f:
-              f.write(f'SUPABASE_URL = "{url}"\n')
-              f.write(f'SUPABASE_ANON_KEY = "{key}"\n')
+          if url and key:
+              with open('src/secrets.py', 'w') as f:
+                  f.write(f'SUPABASE_URL = {json.dumps(url)}\n')
+                  f.write(f'SUPABASE_ANON_KEY = {json.dumps(key)}\n')
+              print('secrets.py written')
+          else:
+              print('No Supabase secrets configured — skipping')
 
       - name: Build with PyInstaller
         run: pyinstaller cyber_survivor.spec --clean --noconfirm


### PR DESCRIPTION
Fixes both Copilot findings on the secrets injection step:

### 1. `if: env.SUPABASE_URL != ''` always evaluates false
The `env.SUPABASE_URL` in the `if:` condition referred to job/workflow-level env vars, but `SUPABASE_URL` was only defined in the step's own `env:` block — so the condition always failed and the step never ran.

**Fix**: Removed the `if:` condition entirely. The step always runs but the Python script checks if both values are non-empty before writing `secrets.py`. If secrets aren't configured, it prints a skip message and the game gracefully falls back to the empty-string defaults in `settings.py`.

### 2. Unsafe string interpolation  
`f'SUPABASE_URL = "{url}"'` would produce invalid Python if the secret contained quotes, backslashes, or newlines.

**Fix**: Use `json.dumps()` which properly escapes all special characters and produces a valid Python string literal.