### PR TITLE
feat: knight shield block, spud gun, weapon roster cleanup, early access UI + super crash fix

### DIFF
--- a/src/entities/enemy.py
+++ b/src/entities/enemy.py
@@ -335,7 +335,8 @@ class Enemy:
         # Corpse linger — stays visible this many ms after death
         self._corpse_until = 0
         self._death_time = 0
-        self._corpse_surf = None  # cached at death
+        self._corpse_surf = None   # body ellipse, cached at death
+        self._spark_surf = None    # spark-dot overlay (fades out in first 33%)
 
         # Animation
         self.anim_offset = random.uniform(0, math.tau)
@@ -796,17 +797,27 @@ class Enemy:
                 half = self.size // 2
                 cw = max(4, int(self.size * 1.2))
                 ch = max(3, int(self.size * 0.35))
-                # Build corpse surface once, reuse with fading alpha
+                # Build corpse surface once, reuse with fading alpha.
+                # Spark dots are on a separate surface so they can fade out
+                # in the first 33% of the corpse lifetime independently.
                 if self._corpse_surf is None:
                     csurf = pygame.Surface((cw, ch + 6), pygame.SRCALPHA)
                     pygame.draw.ellipse(csurf, (40, 20, 20, 220), (0, 0, cw, ch))
                     pygame.draw.ellipse(csurf, (80, 30, 30, 110), (0, 0, cw, ch), 2)
+                    self._corpse_surf = csurf
+                    ssurf = pygame.Surface((cw, ch + 6), pygame.SRCALPHA)
                     for i in range(3):
                         dot_x = cw // 2 + int((i - 1) * cw * 0.25)
-                        pygame.draw.circle(csurf, (200, 20, 20, 200), (dot_x, ch // 2), 2)
-                    self._corpse_surf = csurf
+                        pygame.draw.circle(ssurf, (200, 20, 20, 200), (dot_x, ch // 2), 2)
+                    self._spark_surf = ssurf
+                blit_pos = (sx - cw // 2, sy - ch // 2 + half // 2)
                 self._corpse_surf.set_alpha(alpha)
-                surface.blit(self._corpse_surf, (sx - cw // 2, sy - ch // 2 + half // 2))
+                surface.blit(self._corpse_surf, blit_pos)
+                # Sparks fade out in the first 33% of corpse lifetime
+                spark_a = int(200 * max(0.0, 1.0 - t / 0.33))
+                if self._spark_surf is not None and spark_a > 0:
+                    self._spark_surf.set_alpha(spark_a)
+                    surface.blit(self._spark_surf, blit_pos)
             return
         sx = int(self.x - camera_x)
         sy = int(self.y - camera_y)

--- a/src/entities/enemy.py
+++ b/src/entities/enemy.py
@@ -112,6 +112,12 @@ ENEMY_TYPES = {
         "shoot_cooldown": 9999, "bullet_damage": 0,
         "xp_value": 55, "status_on_hit": "poison",
     },
+    "bulwark": {
+        "hp": 520, "speed": 1.6, "size": 40,
+        "damage": 30, "shoot_range": 0,
+        "shoot_cooldown": 9999, "bullet_damage": 0,
+        "xp_value": 65, "status_on_hit": "slow",
+    },
     "street_preacher": {
         "hp": 6750, "speed": 1.4, "size": 52,
         "damage": 26, "shoot_range": 320,
@@ -164,16 +170,16 @@ ENEMY_TYPES = {
         "xp_value": 48, "status_on_hit": "poison",
     },
     "architect": {
-        "hp": 16800, "speed": 1.2, "size": 56,
-        "damage": 30, "shoot_range": 340,
-        "shoot_cooldown": 800, "bullet_damage": 24,
+        "hp": 22000, "speed": 1.4, "size": 72,
+        "damage": 30, "shoot_range": 380,
+        "shoot_cooldown": 700, "bullet_damage": 26,
         "xp_value": 400, "status_on_hit": "slow",
         "special": "void_rift",
     },
     "nexus": {
-        "hp": 84000, "speed": 0.9, "size": 120,
-        "damage": 70, "shoot_range": 480,
-        "shoot_cooldown": 380, "bullet_damage": 42,
+        "hp": 140000, "speed": 1.1, "size": 140,
+        "damage": 80, "shoot_range": 520,
+        "shoot_cooldown": 320, "bullet_damage": 48,
         "xp_value": 2000, "status_on_hit": "insanity",
         "special": "null_burst",
     },
@@ -308,7 +314,7 @@ class Enemy:
             "street_preacher": (3, 0.50),   # 3 fire shots
             "eldritch_horror": (7, 0.70),   # 7-shot tentacle fan
             "architect":       (3, 0.40),   # 3 void bolts
-            "nexus":           (9, 0.80),   # 9-shot spiral ring
+            "nexus":           (11, 0.85),  # 11-shot spiral ring
         }
         if enemy_type in _boss_spread:
             self.shoot_spread_count, self.shoot_spread_arc = _boss_spread[enemy_type]
@@ -389,6 +395,23 @@ class Enemy:
         self._rat_jitter_timer = 0
         # Cyber raccoon: dodge dash on being hit
         self._raccoon_dodge_timer = -2000
+        # Bulwark: shield-charge-stun state machine
+        self._bulwark_state = "guarding"
+        self._bulwark_charge_cooldown = 3000
+        self._bulwark_last_charge = -2000
+        self._bulwark_charge_start = 0
+        self._bulwark_charge_dx = 0.0
+        self._bulwark_charge_dy = 0.0
+        self._bulwark_stun_until = 0
+        # Architect: phase teleport + shard split
+        self._architect_teleport_cooldown = 3200
+        self._architect_last_teleport = -4000
+        self._architect_split_done = False
+        self._wants_split = False
+        # Nexus: cycles through all boss specials
+        _nexus_pool = ["null_burst", "eldritch_pull", "void_rift", "bleed_storm", "fire_ring"]
+        self._nexus_cycle_pool = _nexus_pool if enemy_type == "nexus" else []
+        self._nexus_cycle_idx = 0
 
     _BOSS_TYPES = frozenset(("iron_sentinel", "supreme_d_lek", "street_preacher",
                              "eldritch_horror", "architect", "nexus",
@@ -427,6 +450,19 @@ class Enemy:
         # Void wisp: phase through attacks
         if self._phase_chance > 0 and random.random() < self._phase_chance:
             return
+        # Bulwark: frontal shield blocks all damage while guarding; double damage when stunned
+        if self.enemy_type == "bulwark":
+            if self._bulwark_state == "guarding" and (knockback_x != 0 or knockback_y != 0):
+                import math as _m
+                hit_angle = _m.atan2(knockback_y, knockback_x)
+                face_angle = _m.atan2(self.face_y, self.face_x)
+                diff = abs(hit_angle - face_angle)
+                if diff > _m.pi:
+                    diff = 2 * _m.pi - diff
+                if diff > _m.pi * 0.5:  # hit from the front — blocked
+                    return
+            elif self._bulwark_state == "stunned":
+                amount = amount * 2  # stunned = 2× damage window
         # Shielder: frontal shield reduces damage by 70%
         if self.enemy_type == "shielder" and (knockback_x != 0 or knockback_y != 0):
             import math as _m
@@ -504,8 +540,11 @@ class Enemy:
                     self.last_shoot_time = now
                     self.gun_flash_timer = now
             else:
-                self.x += (dx / dist) * effective_speed
-                self.y += (dy / dist) * effective_speed
+                # Bulwark handles its own movement in its state machine below
+                if not (self.enemy_type == "bulwark" and
+                        self._bulwark_state in ("charging", "stunned")):
+                    self.x += (dx / dist) * effective_speed
+                    self.y += (dy / dist) * effective_speed
 
         # ── Per-type tactical movement ──
 
@@ -611,6 +650,23 @@ class Enemy:
                 self.x = player_x + math.cos(angle) * td
                 self.y = player_y + math.sin(angle) * td
 
+        # Architect: phase-teleport at distance when below 60% HP; split at 30%
+        if self.enemy_type == "architect":
+            hp_frac = self.hp / self.max_hp if self.max_hp > 0 else 1.0
+            cooldown = 2000 if hp_frac < 0.30 else 3200
+            if hp_frac < 0.60 and now - self._architect_last_teleport > cooldown:
+                self._architect_last_teleport = now
+                # Teleport to a position across the arena (far from current pos)
+                angle = math.atan2(player_y - self.y, player_x - self.x)
+                angle += math.pi + random.uniform(-0.8, 0.8)  # roughly opposite side
+                td = random.uniform(240, 380)
+                self.x = player_x + math.cos(angle) * td
+                self.y = player_y + math.sin(angle) * td
+                self.hit_flash = now  # white flash on teleport
+            if hp_frac < 0.30 and not self._architect_split_done:
+                self._architect_split_done = True
+                self._wants_split = True
+
         # D-Lek: tactical blink to optimal firing range when player closes in
         if self.enemy_type == "d_lek" and now - self._last_teleport > 7000:
             if dist < 100:  # player too close — blink away to shooting range
@@ -677,6 +733,30 @@ class Enemy:
                     self._dog_leap_state = "chase"
                     self._dog_last_leap = now
 
+        # Bulwark: shield-charge-stun state machine
+        if self.enemy_type == "bulwark":
+            if self._bulwark_state == "guarding":
+                # Slow approach with shield raised toward player — handled by default move logic
+                # Start a charge when player is in range and cooldown has passed
+                if dist < 220 and now - self._bulwark_last_charge > self._bulwark_charge_cooldown:
+                    self._bulwark_state = "charging"
+                    self._bulwark_charge_start = now
+                    self._bulwark_last_charge = now
+                    if dist > 0:
+                        self._bulwark_charge_dx = dx / dist
+                        self._bulwark_charge_dy = dy / dist
+            elif self._bulwark_state == "charging":
+                # Rapid dash for 380ms
+                self.x += self._bulwark_charge_dx * 9.0 * speed_mult
+                self.y += self._bulwark_charge_dy * 9.0 * speed_mult
+                if now - self._bulwark_charge_start > 380:
+                    self._bulwark_state = "stunned"
+                    self._bulwark_stun_until = now + 1600
+            elif self._bulwark_state == "stunned":
+                # Cannot move — vulnerable window (already handled in take_damage)
+                if now > self._bulwark_stun_until:
+                    self._bulwark_state = "guarding"
+                    self._bulwark_charge_cooldown = 2800 + random.randint(0, 600)
         # Boss special attacks
         if self._special and self.is_boss and not self._special_active and not self._special2_active:
             if now - self._last_special > self._special_cooldown and dist < self._special_trigger_range:
@@ -709,6 +789,24 @@ class Enemy:
             elapsed = now - self._special_timer
             if elapsed > self._special_duration:
                 self._special_active = False
+                # Nexus: advance to the next special in the rotation
+                if self._nexus_cycle_pool:
+                    self._nexus_cycle_idx = (self._nexus_cycle_idx + 1) % len(self._nexus_cycle_pool)
+                    next_sp = self._nexus_cycle_pool[self._nexus_cycle_idx]
+                    self._special = next_sp
+                    _sp_cycle_params = {
+                        "null_burst":    {"cooldown": 3500, "duration": 700,  "range": 400, "aoe_mult": 4.0},
+                        "eldritch_pull": {"cooldown": 5000, "duration": 1500, "range": 500, "aoe_mult": 3.0},
+                        "void_rift":     {"cooldown": 4000, "duration": 1000, "range": 400, "aoe_mult": 2.5},
+                        "bleed_storm":   {"cooldown": 4500, "duration": 800,  "range": 600, "aoe_mult": 1.0},
+                        "fire_ring":     {"cooldown": 4500, "duration": 1400, "range": 450, "aoe_mult": 2.0},
+                    }
+                    _sp = _sp_cycle_params.get(next_sp, {})
+                    phase_mult = 0.6 if self._phase2_active else 1.0
+                    self._special_cooldown   = int(_sp.get("cooldown", 4000)   * phase_mult)
+                    self._special_duration   = _sp.get("duration", 700)
+                    self._special_trigger_range = _sp.get("range", 400)
+                    self._special_aoe_mult   = _sp.get("aoe_mult", 3.0)
 
         if self._special2_active:
             elapsed2 = now - self._special2_timer
@@ -885,6 +983,8 @@ class Enemy:
             self._draw_cultist(surface, sx, sy, now)
         elif self.enemy_type == "shambler":
             self._draw_shambler(surface, sx, sy, now)
+        elif self.enemy_type == "bulwark":
+            self._draw_bulwark(surface, sx, sy, now)
         elif self.enemy_type == "street_preacher":
             self._draw_preacher(surface, sx, sy, now)
         elif self.enemy_type == "eldritch_horror":
@@ -1032,6 +1132,39 @@ class Enemy:
                             r_surf = self._get_surf(_mr2 * 2, _mr2 * 2)
                             pygame.draw.circle(r_surf, (0, 180, 255, a), (_mr2, _mr2), ring_r, 3)
                             surface.blit(r_surf, (sx - _mr2, sy - _mr2))
+
+            elif self._special == "eldritch_pull":
+                # Gravity pull vortex — purple spiraling ring contracting inward
+                ring_r = int(max_ring * (1.0 - progress))
+                a = int(140 * (1.0 - progress))
+                if ring_r > 2 and a > 0:
+                    _mr2 = max_ring + 2
+                    pull_s = self._get_surf(_mr2 * 2, _mr2 * 2)
+                    pygame.draw.circle(pull_s, (160, 40, 220, a), (_mr2, _mr2), ring_r, 5)
+                    pygame.draw.circle(pull_s, (220, 80, 255, a // 2), (_mr2, _mr2), max(1, ring_r - 8), 2)
+                    surface.blit(pull_s, (sx - _mr2, sy - _mr2))
+
+            elif self._special == "fire_ring":
+                # Ring of fire erupting from boss
+                ring_r = int(max_ring * min(1.0, progress * 1.4))
+                a = int(160 * max(0, 1.0 - progress * 0.7))
+                if ring_r > 0 and a > 0:
+                    _mr2 = max_ring + 2
+                    f_surf = self._get_surf(_mr2 * 2, _mr2 * 2)
+                    pygame.draw.circle(f_surf, (255, 80, 0, a), (_mr2, _mr2), ring_r, 8)
+                    pygame.draw.circle(f_surf, (255, 200, 50, a // 2), (_mr2, _mr2), max(1, ring_r - 10), 3)
+                    surface.blit(f_surf, (sx - _mr2, sy - _mr2))
+
+            elif self._special == "bleed_storm":
+                # Wide crimson pulse radiating outward
+                ring_r = int(max_ring * progress)
+                a = int(120 * (1.0 - progress))
+                if ring_r > 0 and a > 0:
+                    _mr2 = max_ring + 2
+                    b_surf = self._get_surf(_mr2 * 2, _mr2 * 2)
+                    pygame.draw.circle(b_surf, (200, 20, 40, a), (_mr2, _mr2), ring_r, 6)
+                    pygame.draw.circle(b_surf, (255, 60, 60, a // 3), (_mr2, _mr2), ring_r)
+                    surface.blit(b_surf, (sx - _mr2, sy - _mr2))
 
     # ═══════════════════════════════════════════ DALEK drawing
     # ═══════════════════════════════════════════ CYBER RAT drawing
@@ -1560,10 +1693,6 @@ class Enemy:
         pygame.draw.line(surface, gold,
                          (eye_stalk_base_x, eye_stalk_base_y), (eye_x, eye_y), 1)
 
-        # "BOSS" label
-        label = get_font("consolas", 12, True).render("BOSS", True, (255, 60, 60))
-        surface.blit(label, (sx - label.get_width() // 2, sy - half - 26))
-
     # ═══════════════════════════════════════════ CHARGER drawing
     def _draw_charger(self, surface, sx, sy, now):
         is_hit = now - self.hit_flash < 100
@@ -1923,6 +2052,70 @@ class Enemy:
         pygame.draw.circle(surface, (160, 160, 80), (sx - 5, int(sy - 4 + bob)), 3)
         pygame.draw.circle(surface, (160, 160, 80), (sx + 5, int(sy - 4 + bob)), 3)
 
+    # ═══════════════════════════════════════════ BULWARK drawing (Zone 2-3)
+    def _draw_bulwark(self, surface, sx, sy, now):
+        is_hit = now - self.hit_flash < 100
+        half = self.size // 2
+        state = self._bulwark_state
+
+        # Body — heavy armored hexagon
+        pts = []
+        for i in range(6):
+            angle = i * math.pi / 3 + math.pi / 6
+            pts.append((sx + int(math.cos(angle) * (half - 2)),
+                        sy + int(math.sin(angle) * (half - 2))))
+        if state == "stunned":
+            body_color = (255, 60, 60) if not is_hit else (255, 255, 200)
+            pulse = 0.6 + 0.4 * math.sin(now * 0.018)
+            stun_s = self._get_surf((half + 8) * 2, (half + 8) * 2)
+            pygame.draw.circle(stun_s, (255, 80, 50, int(80 * pulse)),
+                               (half + 8, half + 8), half + 6, 4)
+            surface.blit(stun_s, (sx - half - 8, sy - half - 8))
+        elif state == "charging":
+            body_color = (255, 140, 40) if not is_hit else (255, 255, 255)
+        else:
+            body_color = (80, 100, 120) if not is_hit else (255, 255, 255)
+        pygame.draw.polygon(surface, body_color, pts)
+        pygame.draw.polygon(surface, (140, 170, 200), pts, 2)
+
+        # Armor plates — cross pattern over body
+        plate_color = (50, 70, 90) if not is_hit else (220, 240, 255)
+        pygame.draw.line(surface, plate_color,
+                         (sx - half + 6, sy), (sx + half - 6, sy), 5)
+        pygame.draw.line(surface, plate_color,
+                         (sx, sy - half + 6), (sx, sy + half - 6), 5)
+
+        # Red LED eye
+        pygame.draw.circle(surface, (255, 40, 40) if state != "stunned" else (80, 80, 80),
+                           (sx, sy), 5)
+        pygame.draw.circle(surface, (255, 130, 130), (sx, sy), 2)
+
+        # Frontal shield — large flat slab facing the player (face_x, face_y direction)
+        if state in ("guarding", "charging"):
+            shield_dist = half - 2
+            sh_cx = sx + int(self.face_x * shield_dist)
+            sh_cy = sy + int(self.face_y * shield_dist)
+            perp_x, perp_y = -self.face_y, self.face_x
+            half_w = half - 4
+            sh_thick = 8 if state == "charging" else 10
+            sh_pts = [
+                (sh_cx + int(perp_x * half_w), sh_cy + int(perp_y * half_w)),
+                (sh_cx - int(perp_x * half_w), sh_cy - int(perp_y * half_w)),
+                (sh_cx - int(perp_x * half_w) + int(self.face_x * sh_thick),
+                 sh_cy - int(perp_y * half_w) + int(self.face_y * sh_thick)),
+                (sh_cx + int(perp_x * half_w) + int(self.face_x * sh_thick),
+                 sh_cy + int(perp_y * half_w) + int(self.face_y * sh_thick)),
+            ]
+            shield_col = (200, 220, 255) if state == "guarding" else (255, 180, 60)
+            pygame.draw.polygon(surface, shield_col, sh_pts)
+            pygame.draw.polygon(surface, (255, 255, 255), sh_pts, 2)
+
+        # Charging trail effect
+        if state == "charging":
+            trail_s = self._get_surf((half + 6) * 2, (half + 6) * 2)
+            pygame.draw.circle(trail_s, (255, 120, 30, 60), (half + 6, half + 6), half + 4)
+            surface.blit(trail_s, (sx - half - 6, sy - half - 6))
+
     # ═══════════════════════════════════════════ PREACHER drawing (Zone 2 mini boss)
     def _draw_preacher(self, surface, sx, sy, now):
         is_hit = now - self.hit_flash < 100
@@ -1964,10 +2157,6 @@ class Enemy:
         eye_color = (255, 180, 50) if not is_hit else (255, 255, 200)
         pygame.draw.circle(surface, eye_color, (sx - 4, int(sy - 16 + bob)), 3)
         pygame.draw.circle(surface, eye_color, (sx + 4, int(sy - 16 + bob)), 3)
-        # ELITE label
-        label = get_font("consolas", 10, True).render("ELITE", True, (200, 100, 255))
-        surface.blit(label, (sx - label.get_width() // 2, sy - half - 24))
-
     # ═══════════════════════════════════════════ ELDRITCH HORROR drawing (Zone 2 boss)
     def _draw_eldritch_horror(self, surface, sx, sy, now):
         is_hit = now - self.hit_flash < 100
@@ -2021,10 +2210,6 @@ class Enemy:
             fx = sx + int(self.face_x * half)
             fy = sy + int(self.face_y * half)
             pygame.draw.circle(surface, (140, 60, 200), (fx, fy), 10)
-
-        # BOSS label
-        label = get_font("consolas", 12, True).render("BOSS", True, (180, 80, 220))
-        surface.blit(label, (sx - label.get_width() // 2, sy - half - 26))
 
     # ═══════════════════════════════════════════ VOID WISP drawing
     def _draw_void_wisp(self, surface, sx, sy, now):
@@ -2248,10 +2433,6 @@ class Enemy:
             fy = sy + int(self.face_y * half)
             pygame.draw.circle(surface, (100, 220, 255), (fx, fy), 8)
 
-        # ELITE label
-        label = get_font("consolas", 10, True).render("ELITE", True, (100, 200, 255))
-        surface.blit(label, (sx - label.get_width() // 2, sy - half - 24))
-
     # ═══════════════════════════════════════════ NEXUS drawing (Zone 3 final boss)
     def _draw_nexus(self, surface, sx, sy, now):
         is_hit = now - self.hit_flash < 100
@@ -2355,17 +2536,6 @@ class Enemy:
             pygame.draw.circle(gs2, (220, 80, 255, 220), (14, 14), 14)
             surface.blit(gs2, (fx - 14, fy - 14))
             pygame.draw.circle(surface, (255, 200, 255), (fx, fy), 6)
-
-        # ── FINAL BOSS label ─────────────────────────────────────────────────
-        label = get_font("consolas", 13, True).render("FINAL BOSS", True, (255, 60, 180))
-        surface.blit(label, (sx - label.get_width() // 2, sy - half - 32))
-        # Pulsing subtitle
-        sub_a = int(160 + 95 * pulse2)
-        sub_s = get_font("consolas", 9, False).render("THE NEXUS", True, (180, 80, 255))
-        sub_surf = pygame.Surface(sub_s.get_size(), pygame.SRCALPHA)
-        sub_surf.blit(sub_s, (0, 0))
-        sub_surf.set_alpha(sub_a)
-        surface.blit(sub_surf, (sx - sub_surf.get_width() // 2, sy - half - 18))
 
     def _draw_dying_phase(self, surface: pygame.Surface, sx: int, sy: int,
                           elapsed: int, now: int):

--- a/src/entities/enemy.py
+++ b/src/entities/enemy.py
@@ -1179,10 +1179,6 @@ class Enemy:
             pygame.draw.circle(surface, joint_color, (sx + lx_off, leg_base_y + 4), 3)
             pygame.draw.circle(surface, (60, 50, 40), (sx + lx_off, foot_y), 3)
 
-        # ELITE label
-        label = get_font("consolas", 10, True).render("SUB-BOSS", True, (255, 140, 20))
-        surface.blit(label, (sx - label.get_width() // 2, sy - half - 22))
-
     # ═══════════════════════════════════════════ EMPEROR'S ELITE GUARD drawing
     def _draw_emperors_elite_guard(self, surface, sx, sy, now):
         """Black-armored elite D-Lek guard — obsidian hull with red eye."""
@@ -1390,10 +1386,6 @@ class Enemy:
         eye_ey = int(sy - half + 10 + bob + self.face_y * 5)
         pygame.draw.circle(surface, (255, 80, 0), (eye_ex, eye_ey), 5)
         pygame.draw.circle(surface, (255, 200, 50), (eye_ex, eye_ey), 3)
-
-        # "MINI BOSS" label
-        label = get_font("consolas", 10, True).render("ELITE", True, (255, 200, 50))
-        surface.blit(label, (sx - label.get_width() // 2, sy - half - 22))
 
     # ═══════════════════════════════════════════ BIG BOSS drawing
     def _draw_big_boss(self, surface, sx, sy, now):

--- a/src/entities/player.py
+++ b/src/entities/player.py
@@ -146,9 +146,8 @@ class Player:
             self.is_dashing = True
             self.dash_timer = now
             self._dash_charges_remaining -= 1
-            # Start the cooldown clock only once all charges are spent
-            if self._dash_charges_remaining == 0:
-                self.last_dash_time = now
+            # Always record the dash time so the per-charge cooldown resets correctly
+            self.last_dash_time = now
             # Dash in movement (WASD) direction, not mouse facing direction
             self.dash_dx = self.move_dx
             self.dash_dy = self.move_dy
@@ -269,10 +268,14 @@ class Player:
         if self.invincible and now - self.invincible_timer > self.invincible_duration:
             self.invincible = False
 
-        # Refill dash charges after cooldown
+        # Refill dash charges after cooldown — one charge at a time
         if (self._dash_charges_remaining < self.dash_charges_max
                 and now - self.last_dash_time >= self.dash_cooldown):
-            self._dash_charges_remaining = self.dash_charges_max
+            self._dash_charges_remaining = min(
+                self.dash_charges_max, self._dash_charges_remaining + 1)
+            # Keep the timer running so subsequent charges each wait a full cooldown
+            if self._dash_charges_remaining < self.dash_charges_max:
+                self.last_dash_time = now
 
     # ---- draw ----
 

--- a/src/entities/player.py
+++ b/src/entities/player.py
@@ -79,7 +79,7 @@ class Player:
 
         # Super / Energy system — fills on kills, used for class super skill
         self.energy: int = 0
-        self.max_energy: int = 100
+        self.max_energy: int = 120
         # Invincibility frames
         self.invincible = False
         self.invincible_timer = 0
@@ -109,7 +109,7 @@ class Player:
 
     def _apply_weapon_stats(self):
         """Reset weapon stats from the equipped weapon, then restore accumulated bonuses."""
-        self.attack_cooldown = max(80, self.weapon["cooldown"] - self._cooldown_bonus)
+        self.attack_cooldown = max(130, self.weapon["cooldown"] - self._cooldown_bonus)
         self.attack_duration = self.weapon["duration"]
         self.attack_range = self.weapon["range"] + self._range_bonus
 
@@ -381,6 +381,18 @@ class Player:
         pygame.draw.line(surface, visor_color, (sx - 6, head_y - 1), (sx + 6, head_y - 1), 2)
         pygame.draw.line(surface, visor_color, (sx, head_y - 1), (sx, head_y + 4), 2)
         pygame.draw.line(surface, trim_color, (sx, head_y - 10), (sx, head_y - 5), 2)
+
+        # Shield on left arm
+        sh_x = sx - half - 9
+        sh_top = torso_top + 2
+        sh_bot = torso_bot - 6
+        shield_pts = [
+            (sh_x, sh_top), (sh_x + 7, sh_top),
+            (sh_x + 7, sh_bot), (sh_x + 3, sh_bot + 6), (sh_x, sh_bot),
+        ]
+        pygame.draw.polygon(surface, (55, 80, 130), shield_pts)
+        pygame.draw.polygon(surface, trim_color, shield_pts, 1)
+        pygame.draw.line(surface, trim_color, (sh_x + 3, sh_top + 2), (sh_x + 3, sh_bot - 2), 1)
 
     def _draw_archer(self, surface, sx, sy, now, half):
         inv = self.invincible and (now // 80) % 2 == 0

--- a/src/game.py
+++ b/src/game.py
@@ -258,8 +258,8 @@ class Game:
         self._last_damage_time = 0
         self._last_damage_pct = 0.0
         self._dmg_vig_cache = None   # (bucket, Surface)
-        # Super skill flash
-        self._super_flash_until = 0
+        # Super energy lockout — blocks energy gain for 4 s after firing
+        self._super_energy_lockout_until = 0
         # Kill streak combo feedback
         self._kill_streak = 0
         self._kill_streak_time = 0
@@ -735,7 +735,7 @@ class Game:
         elif effect == "passive":
             self._try_add_passive(value, choice.get("name", value))
         elif effect == "dash_charges":
-            p.dash_charges_max = min(2, p.dash_charges_max + 1)
+            p.dash_charges_max = min(4, p.dash_charges_max + 1)
             p._dash_charges_remaining = p.dash_charges_max
             p.upgrade_tiers[base_name] = tier
         elif effect == "skip":
@@ -794,8 +794,16 @@ class Game:
         p.energy = 0
         cls = getattr(p, "char_class", "knight")
 
-        # Flash the screen white — makes it feel like a real super
-        self._super_flash_until = now + 450
+        # Yellow burst particles at player — visual pop without blinding flash
+        self.animations.spawn_death_burst(p.x, p.y, (255, 220, 40), count=28)
+        for _ba in range(0, 360, 36):
+            _br = 42
+            self.animations.spawn_death_burst(
+                p.x + _br * math.cos(math.radians(_ba)),
+                p.y + _br * math.sin(math.radians(_ba)),
+                (255, 255, 120), count=5)
+        # Lock energy accumulation for 4 seconds so super can't chain instantly
+        self._super_energy_lockout_until = now + 4000
         # Brief invincibility so the player can't die in their own super animation
         p.invincible = True
         p.invincible_timer = now
@@ -824,7 +832,7 @@ class Game:
                 self.player_projectiles.spawn_grenades(
                     p.x, p.y, math.cos(a), math.sin(a),
                     damage=damage, count=1, speed=22.0, lifetime=1200,
-                    splash_radius=240, style="bolt",
+                    splash_radius=240, style="bolt", is_super=True,
                 )
             # Burst flash at player position
             for _ba in range(0, 360, 45):
@@ -1213,6 +1221,16 @@ class Game:
         alive = self.spawner.get_alive_enemies()
         for enemy in alive:
             enemy.update(dt, now, self.player.x, self.player.y, world_w, world_h)
+            # Architect: shard split at 30% HP
+            if getattr(enemy, '_wants_split', False):
+                enemy._wants_split = False
+                for _ in range(2):
+                    ang = _rng.uniform(0, math.tau)
+                    sd = _rng.uniform(80, 160)
+                    shard = Enemy(enemy.x + math.cos(ang) * sd,
+                                  enemy.y + math.sin(ang) * sd, "rift_walker")
+                    shard.hp = int(shard.max_hp * 1.5)
+                    self.spawner.enemies.append(shard)
             # Environment collision for enemies too
             ehalf = enemy.size // 2
             enemy.x, enemy.y = self.environment.collide_entity(
@@ -1515,7 +1533,7 @@ class Game:
         for _wkey, _wdmg in self.combat.damage_log:
             self.run_stats.record_hit(_wkey, _wdmg)
             _dmg_energy += _wdmg
-        if _dmg_energy > 0:
+        if _dmg_energy > 0 and now > self._super_energy_lockout_until:
             self.player.energy = min(
                 self.player.max_energy,
                 self.player.energy + _dmg_energy // 20,   # 1 energy per 20 damage
@@ -1574,7 +1592,7 @@ class Game:
             self._kill_streak_time = now
 
         # Super energy — 10 per kill, 60 per boss kill
-        if new_kills > 0:
+        if new_kills > 0 and now > self._super_energy_lockout_until:
             self.player.energy = min(
                 self.player.max_energy,
                 self.player.energy + new_kills * 10 + new_boss_kills * 60
@@ -1647,9 +1665,10 @@ class Game:
             if "poison_strikes" in self.player.passives and enemy.alive and _rng.random() < 0.35:
                 enemy.statuses.apply("poison", now)
             # Energy from projectile damage (1 per 20 dmg, no minimum)
-            self.player.energy = min(
-                self.player.max_energy,
-                self.player.energy + dmg // 20)
+            if now > self._super_energy_lockout_until:
+                self.player.energy = min(
+                    self.player.max_energy,
+                    self.player.energy + dmg // 20)
             # Passive: crit_shots — 20% chance double damage on projectile
             if "crit_shots" in self.player.passives and _rng.random() < 0.20:
                 dmg *= 2
@@ -2089,14 +2108,6 @@ class Game:
                                          border_radius=max(1, 28 - i // 2))
                     self._dmg_vig_cache = (bucket, vig)
                 self.screen.blit(self._dmg_vig_cache[1], (0, 0))
-
-        # ---- Super skill flash ----
-        if now_draw < self._super_flash_until:
-            _sf_age = now_draw - (self._super_flash_until - 250)
-            _sf_alpha = max(0, min(255, int(200 * (1.0 - _sf_age / 250))))
-            _sf = pygame.Surface((SCREEN_WIDTH, SCREEN_HEIGHT), pygame.SRCALPHA)
-            _sf.fill((255, 255, 200, _sf_alpha))
-            self.screen.blit(_sf, (0, 0))
 
         # ---- Kill streak combo text ----
         streak_age = now_draw - self._kill_streak_time

--- a/src/game.py
+++ b/src/game.py
@@ -17,7 +17,7 @@ log = logging.getLogger("game")
 from src.settings import (
     SCREEN_WIDTH, SCREEN_HEIGHT, FPS, TITLE, BLACK,
     TILE_SIZE, MAP_WIDTH, MAP_HEIGHT,
-    ENEMY_DARKNESS_HP_BONUS, XP_PER_KILL, XP_DARKNESS_BONUS,
+    ENEMY_DARKNESS_HP_BONUS, ENEMY_DARKNESS_DMG_BONUS, XP_PER_KILL, XP_DARKNESS_BONUS,
     DROP_CHANCE, MAX_PASSIVES,
     SUPABASE_URL, SUPABASE_ANON_KEY, DATA_DIR,
     CAMERA_ZOOM,
@@ -735,7 +735,7 @@ class Game:
         elif effect == "passive":
             self._try_add_passive(value, choice.get("name", value))
         elif effect == "dash_charges":
-            p.dash_charges_max = min(4, p.dash_charges_max + 1)
+            p.dash_charges_max = min(2, p.dash_charges_max + 1)
             p._dash_charges_remaining = p.dash_charges_max
             p.upgrade_tiers[base_name] = tier
         elif effect == "skip":
@@ -795,11 +795,11 @@ class Game:
         cls = getattr(p, "char_class", "knight")
 
         # Flash the screen white — makes it feel like a real super
-        self._super_flash_until = now + 250
+        self._super_flash_until = now + 450
         # Brief invincibility so the player can't die in their own super animation
         p.invincible = True
         p.invincible_timer = now
-        p.invincible_duration = max(p.invincible_duration, 600)
+        p.invincible_duration = max(p.invincible_duration, 900)
 
         if cls == "archer":
             # STORM BARRAGE — 5 massive explosive arrows spread toward cursor
@@ -817,62 +817,111 @@ class Game:
                 length = math.hypot(dx, dy)
                 if length > 0:
                     dx, dy = dx / length, dy / length
-            damage = int(p.damage * p.damage_multiplier * 25)
+            damage = int(p.damage * p.damage_multiplier * 40)
             base_angle = math.atan2(dy, dx)
-            for offset in (-0.25, -0.12, 0.0, 0.12, 0.25):
+            for offset in (-0.30, -0.15, 0.0, 0.15, 0.30):
                 a = base_angle + offset
                 self.player_projectiles.spawn_grenades(
                     p.x, p.y, math.cos(a), math.sin(a),
-                    damage=damage, count=1, speed=20.0, lifetime=1100,
-                    splash_radius=220,
+                    damage=damage, count=1, speed=22.0, lifetime=1200,
+                    splash_radius=240, style="bolt",
                 )
-            self.animations.add_screen_shake(20)
+            # Burst flash at player position
+            for _ba in range(0, 360, 45):
+                _r = 50
+                self.animations.spawn_death_burst(
+                    p.x + _r * math.cos(math.radians(_ba)),
+                    p.y + _r * math.sin(math.radians(_ba)),
+                    (255, 180, 40), count=8)
+            self.animations.add_screen_shake(38)
             self.sounds.play("boss_roar")
-            self.sounds.play("confetti_boom")
+            self.sounds.play("bolt_boom")
 
         elif cls == "knight":
-            # BLADE STORM NOVA — 20 daggers in a 360° ring, fast + heavy
-            damage = int(p.damage * p.damage_multiplier * 10)
-            for i in range(20):
-                angle = math.radians(i * 18)
-                self.player_projectiles.spawn_daggers(
-                    p.x, p.y, math.cos(angle), math.sin(angle),
-                    damage=damage, count=1, speed=14.0,
-                    lifetime=1400, visual="dagger",
-                )
-            # Second ring offset by 9° slightly slower
-            damage2 = int(p.damage * p.damage_multiplier * 6)
-            for i in range(20):
-                angle = math.radians(i * 18 + 9)
-                self.player_projectiles.spawn_daggers(
-                    p.x, p.y, math.cos(angle), math.sin(angle),
-                    damage=damage2, count=1, speed=8.0,
-                    lifetime=1600, visual="dagger",
-                )
-            self.animations.add_screen_shake(22)
+            # INFERNAL CLEAVE — massive arc melee swing, blue fire DOT on all hit enemies
+            _DEAD = 0.15
+            if self._joystick and (abs(self._ctrl_aim_x) > _DEAD or abs(self._ctrl_aim_y) > _DEAD):
+                aim_l = math.hypot(self._ctrl_aim_x, self._ctrl_aim_y)
+                dx = self._ctrl_aim_x / aim_l if aim_l > 0 else 1.0
+                dy = self._ctrl_aim_y / aim_l if aim_l > 0 else 0.0
+            else:
+                mx, my = pygame.mouse.get_pos()
+                world_x = mx / CAMERA_ZOOM + self.camera.x
+                world_y = my / CAMERA_ZOOM + self.camera.y
+                dx = world_x - p.x
+                dy = world_y - p.y
+                length = math.hypot(dx, dy)
+                if length > 0:
+                    dx, dy = dx / length, dy / length
+
+            ARC_RANGE = 220.0
+            ARC_HALF_RAD = math.radians(80)   # 160° total sweep
+            base_angle = math.atan2(dy, dx)
+            damage = int(p.damage * p.damage_multiplier * 22)
+
+            hit_count = 0
+            for _e in self.spawner.get_alive_enemies():
+                if not _e.alive:
+                    continue
+                ex = _e.x - p.x
+                ey = _e.y - p.y
+                dist = math.hypot(ex, ey)
+                if dist > ARC_RANGE + _e.size:
+                    continue
+                # Angle check — is enemy within the arc cone?
+                enemy_angle = math.atan2(ey, ex)
+                angle_diff = abs(math.atan2(
+                    math.sin(enemy_angle - base_angle),
+                    math.cos(enemy_angle - base_angle)))
+                if angle_diff > ARC_HALF_RAD:
+                    continue
+                _e.take_damage(damage, ex, ey, now)
+                _e.statuses.apply("blue_fire", now)
+                self.combat._add_damage_number(_e.x, _e.y - _e.size - 10, damage, (80, 180, 255))
+                self.animations.spawn_death_burst(_e.x, _e.y, (60, 140, 255), count=14)
+                self.animations.spawn_hit_sparks(_e.x, _e.y, count=8)
+                hit_count += 1
+
+            # Sweeping arc particle trail + shockwave ring
+            self.animations.spawn_arc_sweep(p.x, p.y, dx, dy, arc_deg=160, arc_range=ARC_RANGE)
+            # Central flash burst at player
+            for _bi in range(0, 360, 30):
+                self.animations.spawn_death_burst(
+                    p.x + 30 * math.cos(math.radians(_bi)),
+                    p.y + 30 * math.sin(math.radians(_bi)),
+                    (100, 180, 255), count=6)
+            self.animations.add_screen_shake(45)
             self.sounds.play("boss_roar")
             self.sounds.play("swing")
 
         elif cls == "jester":
-            # CHAOS ERUPTION — 12 grenades + rainbow death burst
-            damage = int(p.damage * p.damage_multiplier * 10)
+            # CHAOS ERUPTION — 12 grenades + rainbow death bursts
+            damage = int(p.damage * p.damage_multiplier * 16)
             for i in range(12):
                 angle = math.radians(i * 30)
                 self.player_projectiles.spawn_grenades(
                     p.x, p.y, math.cos(angle), math.sin(angle),
-                    damage=damage, count=1, speed=9.0, lifetime=900,
-                    splash_radius=160,
+                    damage=damage, count=1, speed=10.0, lifetime=1000,
+                    splash_radius=180,
                 )
-            # Inner ring of faster fast grenades
-            damage2 = int(p.damage * p.damage_multiplier * 6)
+            # Inner ring of faster grenades
+            damage2 = int(p.damage * p.damage_multiplier * 10)
             for i in range(6):
                 angle = math.radians(i * 60 + 15)
                 self.player_projectiles.spawn_grenades(
                     p.x, p.y, math.cos(angle), math.sin(angle),
-                    damage=damage2, count=1, speed=5.0, lifetime=600,
-                    splash_radius=120,
+                    damage=damage2, count=1, speed=6.0, lifetime=700,
+                    splash_radius=140,
                 )
-            self.animations.add_screen_shake(25)
+            # Confetti death bursts in 6 directions
+            _burst_colors = [(255,80,200),(80,255,80),(255,220,0),(80,200,255),(255,120,50),(200,80,255)]
+            for _bi, _ba in enumerate(range(0, 360, 60)):
+                _r = 60
+                self.animations.spawn_death_burst(
+                    p.x + _r * math.cos(math.radians(_ba)),
+                    p.y + _r * math.sin(math.radians(_ba)),
+                    _burst_colors[_bi], count=12)
+            self.animations.add_screen_shake(42)
             self.sounds.play("boss_roar")
             self.sounds.play("confetti_boom")
 
@@ -1170,7 +1219,7 @@ class Game:
                 enemy.x, enemy.y, ehalf)
             # Spawn projectile if enemy wants to shoot
             if enemy.wants_to_shoot:
-                base_dmg = int(enemy.bullet_damage * (1.0 + self.lighting.darkness * 0.5))
+                base_dmg = int(enemy.bullet_damage * (1.0 + self.lighting.darkness * ENEMY_DARKNESS_DMG_BONUS))
                 spread_n = getattr(enemy, 'shoot_spread_count', 1)
                 spread_arc = getattr(enemy, 'shoot_spread_arc', 0.0)
                 # D-lack family fires beam bursts (2 shots side by side)
@@ -1469,7 +1518,7 @@ class Game:
         if _dmg_energy > 0:
             self.player.energy = min(
                 self.player.max_energy,
-                self.player.energy + _dmg_energy // 8,   # 1 energy per 8 damage
+                self.player.energy + _dmg_energy // 20,   # 1 energy per 20 damage
             )
         self.combat.damage_log.clear()
 
@@ -1524,11 +1573,11 @@ class Game:
                 self._kill_streak = new_kills
             self._kill_streak_time = now
 
-        # Super energy — 10 per kill, 50 per boss kill
+        # Super energy — 10 per kill, 60 per boss kill
         if new_kills > 0:
             self.player.energy = min(
                 self.player.max_energy,
-                self.player.energy + new_kills * 10 + new_boss_kills * 40
+                self.player.energy + new_kills * 10 + new_boss_kills * 60
             )
 
         # Mirror shade splitting
@@ -1567,10 +1616,14 @@ class Game:
             now, alive, world_w, world_h, self.player.x, self.player.y)
 
         # Grenade explosion effects
-        for gx, gy, _gdmg, _splash_r in grenade_explosions:
-            self.animations.spawn_confetti_explosion(gx, gy)
+        for gx, gy, _gdmg, _splash_r, gstyle in grenade_explosions:
+            if gstyle == "bolt":
+                self.animations.spawn_bolt_explosion(gx, gy)
+                self.sounds.play("bolt_boom")
+            else:
+                self.animations.spawn_confetti_explosion(gx, gy)
+                self.sounds.play("confetti_boom")
             self.animations.add_screen_shake(4)
-            self.sounds.play("confetti_boom")
 
         for enemy, dmg in thrown_hits:
             # ── Mirror Shade: reflect the hit back as an enemy projectile ──
@@ -1583,10 +1636,20 @@ class Game:
 
             # Record projectile hit in run stats (before crit display modifier)
             self.run_stats.record_hit(self.player.weapon_name, dmg)
-            # Energy from projectile damage (same rate as melee: 1 per 8 dmg)
+            # Weapon on-hit status (fire / poison / etc.)
+            _on_hit_s = self.player.weapon.get("on_hit_status")
+            if _on_hit_s and enemy.alive:
+                enemy.statuses.apply(_on_hit_s, now)
+            # Passive: fire_strikes — 35% chance to ignite on any projectile hit
+            if "fire_strikes" in self.player.passives and enemy.alive and _rng.random() < 0.35:
+                enemy.statuses.apply("fire", now)
+            # Passive: poison_strikes — 35% chance to poison on any projectile hit
+            if "poison_strikes" in self.player.passives and enemy.alive and _rng.random() < 0.35:
+                enemy.statuses.apply("poison", now)
+            # Energy from projectile damage (1 per 20 dmg, no minimum)
             self.player.energy = min(
                 self.player.max_energy,
-                self.player.energy + max(1, dmg // 8))
+                self.player.energy + dmg // 20)
             # Passive: crit_shots — 20% chance double damage on projectile
             if "crit_shots" in self.player.passives and _rng.random() < 0.20:
                 dmg *= 2
@@ -1653,6 +1716,9 @@ class Game:
         # Update projectiles and pickups
         prev_hp2 = self.player.hp
         self.projectiles.update(now, self.player, world_w, world_h)
+        for _bx, _by in self.projectiles.blocked_positions:
+            self.sounds.play("plink")
+            self.animations.spawn_hit_sparks(_bx, _by, count=5)
         if self.player.hp < prev_hp2:
             self.run_stats.record_damage_taken(prev_hp2 - self.player.hp)
             self.sounds.play("hit")
@@ -2027,7 +2093,7 @@ class Game:
         # ---- Super skill flash ----
         if now_draw < self._super_flash_until:
             _sf_age = now_draw - (self._super_flash_until - 250)
-            _sf_alpha = max(0, int(200 * (1.0 - _sf_age / 250)))
+            _sf_alpha = max(0, min(255, int(200 * (1.0 - _sf_age / 250))))
             _sf = pygame.Surface((SCREEN_WIDTH, SCREEN_HEIGHT), pygame.SRCALPHA)
             _sf.fill((255, 255, 200, _sf_alpha))
             self.screen.blit(_sf, (0, 0))

--- a/src/game.py
+++ b/src/game.py
@@ -260,6 +260,8 @@ class Game:
         self._dmg_vig_cache = None   # (bucket, Surface)
         # Super energy lockout — blocks energy gain for 4 s after firing
         self._super_energy_lockout_until = 0
+        # Screenshot capture queue — (capture_at_ms, tag) pairs
+        self._pending_auto_shots: list[tuple[int, str]] = []
         # Kill streak combo feedback
         self._kill_streak = 0
         self._kill_streak_time = 0
@@ -620,12 +622,7 @@ class Game:
                             f"Auto-attack {'ON' if self.auto_attack else 'OFF'}")
                 # Screenshot — F9
                 if event.key == pygame.K_F9:
-                    _ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-                    _shots_dir = os.path.join(DATA_DIR, "screenshots")
-                    os.makedirs(_shots_dir, exist_ok=True)
-                    _path = os.path.join(_shots_dir, f"screenshot_{_ts}.png")
-                    pygame.image.save(self.screen, _path)
-                    self.toasts.show("Screenshot saved", os.path.basename(_path), (100, 220, 255))
+                    self._save_screenshot("manual")
                 # Attack — Space or Left click proxy via J key
                 if event.key in (pygame.K_SPACE, pygame.K_j) and not self._player_dying and not self.game_over:
                     if self.player.try_attack(now):
@@ -740,6 +737,20 @@ class Game:
             p.upgrade_tiers[base_name] = tier
         elif effect == "skip":
             pass  # player forfeited the upgrade
+
+    # ── Screenshots ──────────────────────────────────────────────────────────
+
+    _SCREENSHOTS_DIR = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "screenshots")
+
+    def _save_screenshot(self, tag: str = "manual"):
+        """Save a PNG of the current frame to <project>/screenshots/."""
+        ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")[:-3]
+        os.makedirs(self._SCREENSHOTS_DIR, exist_ok=True)
+        path = os.path.join(self._SCREENSHOTS_DIR, f"{ts}_{tag}.png")
+        pygame.image.save(self.screen, path)
+        self.toasts.show("Screenshot", os.path.basename(path), (100, 220, 255))
 
     def _try_add_passive(self, key: str, display_name: str):
         """Add a passive, or open swap screen if slots are full."""
@@ -1198,12 +1209,16 @@ class Game:
         if self.spawner.just_started_wave and self.spawner.boss_wave:
             self.sounds.play("boss_roar")
             self.sounds.start_boss_music(self.current_zone)
+            # Auto-screenshot 400 ms after boss wave starts (effects visible)
+            self._pending_auto_shots.append((now + 400, "boss_spawn"))
 
         # Stop boss music when boss wave ends (no more boss enemies alive)
         if self.sounds.boss_music_playing:
             alive_bosses = [e for e in self.spawner.get_alive_enemies() if e.is_boss]
             if not alive_bosses and not self.spawner.wave_active:
                 self.sounds.stop_boss_music()
+                # Auto-screenshot 500 ms after boss is cleared — capture the victory
+                self._pending_auto_shots.append((now + 500, "boss_cleared"))
 
         # Campfire is active only between waves
         self.campfire.set_active(not self.spawner.wave_active)
@@ -1867,6 +1882,8 @@ class Game:
                 self.player.x, self.player.y, (255, 255, 100), count=24)
             self.animations.add_screen_shake(4)
             self.sounds.play("levelup")
+            # Auto-screenshot 300 ms later to catch the level-up card
+            self._pending_auto_shots.append((now + 300, "levelup"))
 
     def _spawn_healing_drop(self, x: float, y: float, kind: str):
         """Spawn the appropriate healing pickup for a healing prop type."""
@@ -2136,6 +2153,13 @@ class Game:
 
         # ---- Toast notifications ----
         self.toasts.draw(self.screen)
+
+        # ---- Auto-screenshot queue ----
+        if self._pending_auto_shots:
+            for _shot_at, _shot_tag in list(self._pending_auto_shots):
+                if now_draw >= _shot_at:
+                    self._save_screenshot(_shot_tag)
+                    self._pending_auto_shots.remove((_shot_at, _shot_tag))
 
         # ---- Custom cursor (always drawn last) ----
         mx_c, my_c = pygame.mouse.get_pos()

--- a/src/settings.py
+++ b/src/settings.py
@@ -80,7 +80,7 @@ PLAYER_MAX_SPEED = 9                # hard cap — prevents melee from feeling w
 PLAYER_MAX_RANGE = 135              # hard cap on attack range
 PLAYER_DASH_SPEED = 18
 PLAYER_DASH_DURATION = 150          # ms
-PLAYER_DASH_COOLDOWN = 800          # ms
+PLAYER_DASH_COOLDOWN = 1000          # ms
 
 # -- Enemies --
 ENEMY_SPEED = 2.8
@@ -127,7 +127,7 @@ PLAYER_LIGHT_RADIUS_MAX = 180       # px – starting personal light radius
 PLAYER_LIGHT_RADIUS_MIN = 50        # px – minimum light radius
 LIGHT_SHRINK_RATE = 0.015           # px lost per frame away from campfire
 LIGHT_RESTORE_RATE = 0.6            # px gained per frame near campfire
-DARKNESS_GROW_RATE = 0.0004         # darkness per frame away from campfire (0→1)
+DARKNESS_GROW_RATE = 0.0002         # darkness per frame away from campfire (0→1)
 DARKNESS_DECAY_RATE = 0.003         # darkness lost per frame near campfire
 
 # -- Backend (Supabase) --
@@ -138,10 +138,10 @@ try:
 except ImportError:
     SUPABASE_URL = ""
     SUPABASE_ANON_KEY = ""
-DARKNESS_MAX = 0.85                 # max darkness alpha (0..1)
-XP_DARKNESS_BONUS = 2.0             # max XP multiplier at full darkness
+DARKNESS_MAX = 0.65                 # max darkness alpha (0..1) — capped at old 2.3x visual level
+XP_DARKNESS_BONUS = 1.54            # at DARKNESS_MAX (0.65) gives exactly 2x XP
 ENEMY_DARKNESS_HP_BONUS = 0.6       # extra HP fraction at full darkness
-ENEMY_DARKNESS_DMG_BONUS = 0.5      # extra damage fraction at full darkness
+ENEMY_DARKNESS_DMG_BONUS = 1.54     # at DARKNESS_MAX (0.65) gives exactly 2x enemy damage
 
 # -- Map --
 TILE_SIZE = 64

--- a/src/settings.py
+++ b/src/settings.py
@@ -45,7 +45,7 @@ DARK_GRAY = (40, 40, 40)
 LIGHT_GRAY = (180, 180, 180)
 
 # -- Passives --
-MAX_PASSIVES = 4
+MAX_PASSIVES = 5
 
 # icon letter + color for HUD display  (key → (icon, color))
 PASSIVE_INFO = {

--- a/src/settings.py
+++ b/src/settings.py
@@ -12,10 +12,27 @@ VERSION = "0.9.5"
 
 # -- User data directory (%APPDATA%/CyberSurvivor on Windows) --
 import os as _os
-DATA_DIR = _os.path.join(_os.environ.get("APPDATA", ""), "CyberSurvivor") \
-    if _os.name == "nt" \
-    else _os.path.join(_os.path.expanduser("~"), ".cyber_survivor")
-_os.makedirs(DATA_DIR, exist_ok=True)
+
+def _resolve_data_dir() -> str:
+    if _os.name == "nt":
+        # Prefer APPDATA; fall back to LOCALAPPDATA then expanduser so we
+        # never silently resolve to a relative path when the env var is unset.
+        appdata = (_os.environ.get("APPDATA")
+                   or _os.environ.get("LOCALAPPDATA")
+                   or _os.path.join(_os.path.expanduser("~"), "AppData", "Roaming"))
+        return _os.path.join(appdata, "CyberSurvivor")
+    return _os.path.join(_os.path.expanduser("~"), ".cyber_survivor")
+
+DATA_DIR = _resolve_data_dir()
+try:
+    _os.makedirs(DATA_DIR, exist_ok=True)
+except OSError:
+    # Fallback: if the preferred location isn't writable (e.g. read-only
+    # filesystem or missing permissions) use a writable temp directory so
+    # the game can still start; saves won't persist across sessions.
+    import tempfile as _tempfile
+    DATA_DIR = _os.path.join(_tempfile.gettempdir(), "CyberSurvivor")
+    _os.makedirs(DATA_DIR, exist_ok=True)
 
 # -- Colors --
 BLACK = (0, 0, 0)

--- a/src/systems/animations.py
+++ b/src/systems/animations.py
@@ -55,6 +55,7 @@ class DeathAnimation:
         "drone":         (280, 20,  "burst_ring"),
         "cultist":       (400, 30,  "dissolve"),
         "shambler":      (500, 40,  "splat"),
+        "bulwark":       (450, 38,  "shatter"),
         "street_preacher": (750, 50,  "boss_explosion"),
         "eldritch_horror":(1200,78, "big_boss_explosion"),
         "void_wisp":     (250, 18,  "dissolve"),

--- a/src/systems/animations.py
+++ b/src/systems/animations.py
@@ -271,6 +271,44 @@ class AnimationSystem:
             self.particles.append(
                 Particle(world_x, world_y, dx, dy, life, c, size, gravity=0.15))
 
+    def spawn_bolt_explosion(self, world_x: float, world_y: float):
+        """Bright orange-white energy burst for explosive bolt detonation."""
+        for _ in range(28):
+            angle = random.uniform(0, math.tau)
+            speed = random.uniform(3.0, 9.0)
+            dx = math.cos(angle) * speed
+            dy = math.sin(angle) * speed
+            life = random.randint(12, 28)
+            c = random.choice([
+                (255, 255, 220), (255, 220, 100), (255, 160, 40),
+                (255, 100, 20), (255, 255, 255)])
+            size = random.uniform(2, 6)
+            self.particles.append(
+                Particle(world_x, world_y, dx, dy, life, c, size, gravity=0.05))
+
+    def spawn_arc_sweep(self, world_x: float, world_y: float,
+                        aim_dx: float, aim_dy: float,
+                        arc_deg: float = 160.0, arc_range: float = 220.0):
+        """Blue-white sweeping blade arc for knight super skill."""
+        base_angle = math.atan2(aim_dy, aim_dx)
+        half = math.radians(arc_deg / 2)
+        # Particles spread along the arc at multiple distances
+        for step in range(60):
+            sweep_angle = base_angle - half + (step / 59) * 2 * half
+            dist = random.uniform(arc_range * 0.3, arc_range)
+            wx = world_x + math.cos(sweep_angle) * dist
+            wy = world_y + math.sin(sweep_angle) * dist
+            # Radial outward velocity
+            speed = random.uniform(2.5, 7.0)
+            pdx = math.cos(sweep_angle) * speed
+            pdy = math.sin(sweep_angle) * speed
+            life = random.randint(18, 38)
+            c = random.choice([
+                (80, 160, 255), (140, 200, 255), (200, 230, 255),
+                (255, 255, 255), (60, 120, 255), (180, 220, 255)])
+            size = random.uniform(2.5, 6.5)
+            self.particles.append(Particle(wx, wy, pdx, pdy, life, c, size, gravity=0.0))
+
     def spawn_dash_trail(self, world_x: float, world_y: float, dash_dx: float, dash_dy: float):
         """2-3 wind streak particles behind the player during a dash."""
         for _ in range(3):

--- a/src/systems/boss_chest.py
+++ b/src/systems/boss_chest.py
@@ -23,6 +23,8 @@ CHEST_UPGRADES = [
     {"name": "Chain Lightning",    "icon": "Z", "color": (100, 230, 255), "effect": "passive",  "value": "chain_lightning"},
     {"name": "Second Wind",        "icon": "L", "color": (255, 100, 100), "effect": "passive",  "value": "second_wind"},
     {"name": "Explosive Rounds",   "icon": "E", "color": (255, 150, 0),   "effect": "passive",  "value": "explosive_kills"},
+    {"name": "Burning Strikes",    "icon": "F", "color": (255, 110, 20),  "effect": "passive",  "value": "fire_strikes"},
+    {"name": "Toxic Strikes",      "icon": "P", "color": (80, 210, 50),   "effect": "passive",  "value": "poison_strikes"},
 ]
 
 

--- a/src/systems/combat.py
+++ b/src/systems/combat.py
@@ -39,6 +39,18 @@ class CombatSystem:
                 enemy.take_damage(total_dmg, kb_x, kb_y, now, kb_mult)
                 self.damage_log.append((player.weapon_name, total_dmg))
                 self._add_damage_number(enemy.x, enemy.y - enemy.size, total_dmg, (255, 255, 100))
+                # Weapon on-hit status (fire / poison / etc.)
+                on_hit = player.weapon.get("on_hit_status")
+                if on_hit and enemy.alive:
+                    enemy.statuses.apply(on_hit, now)
+                # Passive: fire_strikes — 35% chance to ignite on any melee hit
+                if "fire_strikes" in getattr(player, 'passives', []) and enemy.alive:
+                    if random.random() < 0.35:
+                        enemy.statuses.apply("fire", now)
+                # Passive: poison_strikes — 35% chance to poison on any melee hit
+                if "poison_strikes" in getattr(player, 'passives', []) and enemy.alive:
+                    if random.random() < 0.35:
+                        enemy.statuses.apply("poison", now)
                 # Passive: vampiric_strike — heal 4 per hit
                 if "vampiric_strike" in getattr(player, 'passives', []):
                     player.hp = min(player.max_hp, player.hp + 4)

--- a/src/systems/compendium.py
+++ b/src/systems/compendium.py
@@ -25,7 +25,7 @@ DISPLAY_NAMES: dict[str, str] = {
     "charger":         "Charger",
     "shielder":        "Shielder",
     "spitter":         "Spitter",
-    "iron_sentinel":   "Iron Sentinel",
+    "iron_sentinel":   "D-Lak Sentinel",
     "supreme_d_lek":   "D-Lek Emperor",
     "emperors_elite_guard": "Emperor's Elite Guard",
     # Zone 2

--- a/src/systems/compendium.py
+++ b/src/systems/compendium.py
@@ -25,7 +25,7 @@ DISPLAY_NAMES: dict[str, str] = {
     "charger":         "Charger",
     "shielder":        "Shielder",
     "spitter":         "Spitter",
-    "iron_sentinel":   "D-Lak Sentinel",
+    "iron_sentinel":   "D-Lek Sentinel",
     "supreme_d_lek":   "D-Lek Emperor",
     "emperors_elite_guard": "Emperor's Elite Guard",
     # Zone 2

--- a/src/systems/compendium.py
+++ b/src/systems/compendium.py
@@ -34,6 +34,7 @@ DISPLAY_NAMES: dict[str, str] = {
     "drone":           "Drone",
     "cultist":         "Cultist",
     "shambler":        "Shambler",
+    "bulwark":         "Bulwark",
     "street_preacher": "Street Preacher",
     "eldritch_horror": "Eldritch Horror",
     # Zone 3
@@ -63,6 +64,7 @@ ENEMY_ZONES: dict[str, str] = {
     "drone":           "city",
     "cultist":         "city",
     "shambler":        "city",
+    "bulwark":         "city",
     "street_preacher": "city",
     "eldritch_horror": "city",
     "specter":         "abyss",
@@ -92,6 +94,7 @@ ENEMY_LORE: dict[str, str] = {
     "drone":           "Surveillance unit retasked\nfor elimination.\nOrbits before opening fire.",
     "cultist":         "Devoted to the Eldritch Horror.\nChannels dark energy before\nunleashing bursts.",
     "shambler":        "An ambulatory mass of rot.\nSlow but hits like a wall.\nDon't get surrounded.",
+    "bulwark":         "Front-armoured enforcer.\nShield blocks all frontal hits.\nFlank or bait the charge.",
     "street_preacher": "Fire-touched zealot.\nPreaches in flames.\nA mini-boss of pure devotion.",
     "eldritch_horror": "Tentacled nightmare from\nbeyond sane geometry.\nBoss of the Ruined City.",
     "specter":         "A wraith refined through void\nexposure. Faster, deadlier,\nand it bleeds you dry.",
@@ -110,7 +113,7 @@ COMPENDIUM_ORDER: list[str] = [
     "cyber_rat", "cyber_raccoon", "d_lek", "charger", "shielder", "spitter",
     "mega_cyber_deer", "iron_sentinel", "supreme_d_lek", "emperors_elite_guard",
     # Zone 2
-    "cyber_zombie", "cyber_dog", "drone", "cultist", "shambler",
+    "cyber_zombie", "cyber_dog", "drone", "cultist", "shambler", "bulwark",
     "street_preacher", "eldritch_horror",
     # Zone 3
     "specter", "void_wisp", "rift_walker", "mirror_shade",

--- a/src/systems/game_actions.py
+++ b/src/systems/game_actions.py
@@ -46,6 +46,8 @@ def process_enemy_death(enemy, player, alive, animations, combat, sounds,
         color = (80, 200, 50)
     elif enemy.enemy_type in ("cyber_zombie", "shambler"):
         color = (80, 120, 60)
+    elif enemy.enemy_type == "bulwark":
+        color = (140, 180, 220)
     elif enemy.enemy_type == "cyber_dog":
         color = (180, 180, 190)
     elif enemy.enemy_type == "drone":

--- a/src/systems/game_actions.py
+++ b/src/systems/game_actions.py
@@ -152,7 +152,9 @@ def fire_player_projectile(player, player_projectiles, sounds):
     if w.get("orbiter"):
         player_projectiles.spawn_orbiter(px, py, fx, fy, dmg, w.get("orbiter_type", "banana"))
     elif w.get("grenade"):
-        player_projectiles.spawn_grenades(px, py, fx, fy, dmg, cnt, spd, lt)
+        splash_r = w.get("splash_radius", 60)
+        gstyle = w.get("proj_style", "confetti")
+        player_projectiles.spawn_grenades(px, py, fx, fy, dmg, cnt, spd, lt, splash_r, gstyle)
     else:
         vis = w.get("proj_visual", "dagger")
         prc = w.get("piercing", False)
@@ -161,5 +163,5 @@ def fire_player_projectile(player, player_projectiles, sounds):
     if "Chicken" in w.get("name", ""):
         sounds.play("chicken")
     else:
-        sounds.play("throw")
+        sounds.play(w.get("sound", "throw"))
     return True

--- a/src/systems/profile.py
+++ b/src/systems/profile.py
@@ -25,8 +25,12 @@ log = logging.getLogger("profile")
 
 from src.settings import DATA_DIR
 
-_PROJECT_ROOT = DATA_DIR
-_ROOT_POINTER = os.path.join(_PROJECT_ROOT, "profile.json")
+_USER_DATA_DIR = DATA_DIR
+_ROOT_POINTER = os.path.join(_USER_DATA_DIR, "profile.json")
+
+# The directory that old versions of the game (pre-AppData migration) wrote
+# saves into — the project/install root, i.e. the folder containing src/.
+_LEGACY_INSTALL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 # ── Storage backends ───────────────────────────────────────────────────────────
@@ -176,7 +180,7 @@ def _load_desktop_profile() -> PlayerProfile:
         _migrate_root_saves(pid)
 
     # 2. Per-player storage inside profiles/{pid}/
-    profile_dir = os.path.join(_PROJECT_ROOT, "profiles", pid)
+    profile_dir = os.path.join(_USER_DATA_DIR, "profiles", pid)
     storage = FileStorage(profile_dir)
 
     # 3. Load profile metadata from per-player directory
@@ -202,17 +206,31 @@ def _write_root_pointer(player_id: str, display_name: str, consent) -> None:
 
 
 def _migrate_root_saves(new_pid: str) -> None:
-    """Move any existing root-level saves into the new per-player directory."""
-    dest_dir = os.path.join(_PROJECT_ROOT, "profiles", new_pid)
+    """Move any existing root-level saves into the new per-player directory.
+
+    Checks two locations for legacy saves:
+    1. The install/project root (data lived here before v0.9.x AppData migration).
+    2. The AppData root (saves that landed there from an intermediate build).
+    """
+    dest_dir = os.path.join(_USER_DATA_DIR, "profiles", new_pid)
+    search_roots = []
+    # Avoid duplicate work if both paths happen to resolve to the same dir
+    seen = set()
+    for root in (_LEGACY_INSTALL_DIR, _USER_DATA_DIR):
+        if root not in seen:
+            search_roots.append(root)
+            seen.add(root)
     for fname in ("legacy_save.json", "compendium_save.json"):
-        src = os.path.join(_PROJECT_ROOT, fname)
-        if os.path.exists(src):
-            try:
-                os.makedirs(dest_dir, exist_ok=True)
-                dst = os.path.join(dest_dir, fname)
-                if not os.path.exists(dst):  # never overwrite a newer file
-                    import shutil
-                    shutil.move(src, dst)
-                    log.info("Migrated %s → profiles/%s/%s", fname, new_pid, fname)
-            except OSError as e:
-                log.warning("Migration of %s failed: %s", fname, e)
+        for search_root in search_roots:
+            src = os.path.join(search_root, fname)
+            if os.path.exists(src):
+                try:
+                    os.makedirs(dest_dir, exist_ok=True)
+                    dst = os.path.join(dest_dir, fname)
+                    if not os.path.exists(dst):  # never overwrite a newer file
+                        import shutil
+                        shutil.move(src, dst)
+                        log.info("Migrated %s → profiles/%s/%s", fname, new_pid, fname)
+                except OSError as e:
+                    log.warning("Migration of %s failed: %s", fname, e)
+                break  # found it in this root; don't keep searching

--- a/src/systems/profile.py
+++ b/src/systems/profile.py
@@ -30,7 +30,7 @@ _ROOT_POINTER = os.path.join(_USER_DATA_DIR, "profile.json")
 
 # The directory that old versions of the game (pre-AppData migration) wrote
 # saves into — the project/install root, i.e. the folder containing src/.
-_LEGACY_INSTALL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_LEGACY_INSTALL_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 # ── Storage backends ───────────────────────────────────────────────────────────

--- a/src/systems/projectiles.py
+++ b/src/systems/projectiles.py
@@ -419,9 +419,6 @@ class ConfettiGrenade:
             surface.blit(ss, (spark_x - 2, spark_y - 2))
 
 
-import random as _rng
-
-
 class PlayerProjectileSystem:
     """Manages player-thrown projectiles (daggers, orbiters, grenades)."""
 
@@ -476,7 +473,8 @@ class PlayerProjectileSystem:
                        damage: int, count: int = 1, speed: float = 5.5,
                        lifetime: int = 600, splash_radius: int = 60, style: str = "confetti",
                        is_super: bool = False):
-        """Spawn confetti grenades."""
+        """Spawn thrown projectiles that explode on impact or timeout.
+        style='confetti' for jester grenades, style='bolt' for energy bolts."""
         base_angle = math.atan2(facing_y, facing_x)
         for i in range(count):
             offset = (i - (count - 1) / 2) * 0.2

--- a/src/systems/projectiles.py
+++ b/src/systems/projectiles.py
@@ -1,5 +1,6 @@
 import pygame
 import math
+import random
 from src.settings import ENEMY_BULLET_SPEED, ENEMY_BULLET_SIZE, ENEMY_BULLET_COLOR
 
 
@@ -63,6 +64,7 @@ class ProjectileSystem:
 
     def __init__(self):
         self.bullets: list[Projectile] = []
+        self.blocked_positions: list[tuple] = []  # (x, y) knight-blocked bullets this frame
 
     def spawn(self, x: float, y: float, target_x: float, target_y: float, damage: int,
                style: str = "circle"):
@@ -74,6 +76,7 @@ class ProjectileSystem:
         self.bullets.append(Projectile(x, y, dx / dist, dy / dist, damage, style))
 
     def update(self, now: int, player, world_w: int, world_h: int):
+        self.blocked_positions.clear()
         for b in self.bullets:
             b.update(now)
             # Out-of-bounds check
@@ -81,7 +84,11 @@ class ProjectileSystem:
                 b.alive = False
             # Hit player
             if b.alive and b.rect.colliderect(player.rect):
-                player.take_damage(b.damage, now)
+                # Knight passive shield block — 28% base chance
+                if getattr(player, 'char_class', '') == 'knight' and random.random() < 0.28:
+                    self.blocked_positions.append((b.x, b.y))
+                else:
+                    player.take_damage(b.damage, now)
                 b.alive = False
         self.bullets = [b for b in self.bullets if b.alive]
 
@@ -132,6 +139,8 @@ class ThrownDagger:
             self._draw_bolt(surface, sx, sy)
         elif self.visual == "pellet":
             self._draw_pellet(surface, sx, sy)
+        elif self.visual == "potato":
+            self._draw_potato(surface, sx, sy)
         else:
             self._draw_dagger(surface, sx, sy)
 
@@ -178,6 +187,20 @@ class ThrownDagger:
 
     def _draw_pellet(self, surface, sx, sy):
         pygame.draw.circle(surface, (255, 255, 100), (sx, sy), 3)
+
+    def _draw_potato(self, surface, sx, sy):
+        """Irregularly shaped brown projectile tumbling through the air."""
+        now = pygame.time.get_ticks()
+        spin = int(self.angle * 5) % 4  # 4-frame tumble
+        offsets = [(0, 0), (1, -1), (0, -1), (-1, 0)][spin]
+        ox, oy = offsets
+        # Main lumpy oval
+        pygame.draw.ellipse(surface, (160, 120, 60), (sx - 6 + ox, sy - 4 + oy, 12, 9))
+        pygame.draw.ellipse(surface, (120, 90, 40), (sx - 6 + ox, sy - 4 + oy, 12, 9), 1)
+        # Highlight
+        pygame.draw.ellipse(surface, (210, 175, 100), (sx - 3 + ox, sy - 3 + oy, 5, 3))
+        # Shadow dot (eye-like)
+        pygame.draw.circle(surface, (90, 60, 25), (sx + 1 + ox, sy + 1 + oy), 1)
         pygame.draw.circle(surface, (255, 255, 255), (sx, sy), 1)
         glow = pygame.Surface((8, 8), pygame.SRCALPHA)
         pygame.draw.circle(glow, (255, 255, 100, 50), (4, 4), 4)
@@ -300,7 +323,7 @@ class ConfettiGrenade:
         (100, 200, 255), (255, 150, 50), (200, 100, 255),
     ]
 
-    def __init__(self, x: float, y: float, dx: float, dy: float, damage: int):
+    def __init__(self, x: float, y: float, dx: float, dy: float, damage: int, style: str = "confetti"):
         self.x = x
         self.y = y
         self.dx = dx
@@ -314,6 +337,7 @@ class ConfettiGrenade:
         self.size = 5
         self.splash_radius = 60  # explosion hits enemies in this radius
         self.angle = math.atan2(dy, dx)
+        self.style = style
 
     def update(self, now: int):
         if not self.alive:
@@ -335,21 +359,38 @@ class ConfettiGrenade:
             return
         sx = int(self.x - camera_x)
         sy = int(self.y - camera_y)
-        # Round grenade body
-        pygame.draw.circle(surface, (80, 80, 80), (sx, sy), 6)
-        pygame.draw.circle(surface, (255, 100, 200), (sx, sy), 6, 2)
-        # Confetti pattern
-        for i in range(3):
-            a = self.angle + i * 2.1
-            cx = sx + int(math.cos(a) * 3)
-            cy = sy + int(math.sin(a) * 3)
-            pygame.draw.circle(surface, self.CONFETTI_COLORS[i], (cx, cy), 1)
-        # Fuse spark
-        spark_x = sx + int(math.cos(self.angle) * 8)
-        spark_y = sy + int(math.sin(self.angle) * 8) - 3
-        ss = pygame.Surface((4, 4), pygame.SRCALPHA)
-        pygame.draw.circle(ss, (255, 255, 100, 200), (2, 2), 2)
-        surface.blit(ss, (spark_x - 2, spark_y - 2))
+        if self.style == "bolt":
+            # Glowing energy bolt — bright orange-white core with pulsing halo
+            now = pygame.time.get_ticks()
+            pulse = 0.7 + 0.3 * math.sin(now * 0.025)
+            halo_r = int(10 * pulse)
+            halo_s = pygame.Surface((halo_r * 2 + 4, halo_r * 2 + 4), pygame.SRCALPHA)
+            pygame.draw.circle(halo_s, (255, 180, 60, 80), (halo_r + 2, halo_r + 2), halo_r)
+            surface.blit(halo_s, (sx - halo_r - 2, sy - halo_r - 2))
+            pygame.draw.circle(surface, (255, 220, 100), (sx, sy), 5)
+            pygame.draw.circle(surface, (255, 255, 220), (sx, sy), 3)
+            # Trailing spark trail in direction of movement
+            trail_x = sx - int(math.cos(self.angle) * 8)
+            trail_y = sy - int(math.sin(self.angle) * 8)
+            ts = pygame.Surface((6, 6), pygame.SRCALPHA)
+            pygame.draw.circle(ts, (255, 140, 40, 140), (3, 3), 3)
+            surface.blit(ts, (trail_x - 3, trail_y - 3))
+        else:
+            # Round grenade body
+            pygame.draw.circle(surface, (80, 80, 80), (sx, sy), 6)
+            pygame.draw.circle(surface, (255, 100, 200), (sx, sy), 6, 2)
+            # Confetti pattern
+            for i in range(3):
+                a = self.angle + i * 2.1
+                cx = sx + int(math.cos(a) * 3)
+                cy = sy + int(math.sin(a) * 3)
+                pygame.draw.circle(surface, self.CONFETTI_COLORS[i], (cx, cy), 1)
+            # Fuse spark
+            spark_x = sx + int(math.cos(self.angle) * 8)
+            spark_y = sy + int(math.sin(self.angle) * 8) - 3
+            ss = pygame.Surface((4, 4), pygame.SRCALPHA)
+            pygame.draw.circle(ss, (255, 255, 100, 200), (2, 2), 2)
+            surface.blit(ss, (spark_x - 2, spark_y - 2))
 
 
 import random as _rng
@@ -407,7 +448,7 @@ class PlayerProjectileSystem:
 
     def spawn_grenades(self, x: float, y: float, facing_x: float, facing_y: float,
                        damage: int, count: int = 1, speed: float = 5.5,
-                       lifetime: int = 600, splash_radius: int = 60):
+                       lifetime: int = 600, splash_radius: int = 60, style: str = "confetti"):
         """Spawn confetti grenades."""
         base_angle = math.atan2(facing_y, facing_x)
         for i in range(count):
@@ -415,7 +456,7 @@ class PlayerProjectileSystem:
             a = base_angle + offset
             dx = math.cos(a)
             dy = math.sin(a)
-            g = ConfettiGrenade(x, y, dx, dy, damage)
+            g = ConfettiGrenade(x, y, dx, dy, damage, style=style)
             g.speed = speed
             g.lifetime = lifetime
             g.splash_radius = splash_radius
@@ -480,7 +521,7 @@ class PlayerProjectileSystem:
                 g.exploded = True
             if not g.alive:
                 if g.exploded:
-                    grenade_explosions.append((g.x, g.y, g.damage, g.splash_radius))
+                    grenade_explosions.append((g.x, g.y, g.damage, g.splash_radius, g.style))
                 continue
             g_rect = pygame.Rect(g.x - g.size, g.y - g.size, g.size * 2, g.size * 2)
             for enemy in enemies:
@@ -489,12 +530,12 @@ class PlayerProjectileSystem:
                 if g_rect.colliderect(enemy.rect):
                     g.exploded = True
                     g.alive = False
-                    grenade_explosions.append((g.x, g.y, g.damage, g.splash_radius))
+                    grenade_explosions.append((g.x, g.y, g.damage, g.splash_radius, g.style))
                     break
         self.grenades = [g for g in self.grenades if g.alive]
 
         # Process grenade splash damage
-        for gx, gy, gdmg, splash_r in grenade_explosions:
+        for gx, gy, gdmg, splash_r, _gstyle in grenade_explosions:
             for enemy in enemies:
                 if not enemy.alive:
                     continue

--- a/src/systems/projectiles.py
+++ b/src/systems/projectiles.py
@@ -323,7 +323,8 @@ class ConfettiGrenade:
         (100, 200, 255), (255, 150, 50), (200, 100, 255),
     ]
 
-    def __init__(self, x: float, y: float, dx: float, dy: float, damage: int, style: str = "confetti"):
+    def __init__(self, x: float, y: float, dx: float, dy: float, damage: int, style: str = "confetti",
+                 is_super: bool = False):
         self.x = x
         self.y = y
         self.dx = dx
@@ -338,6 +339,7 @@ class ConfettiGrenade:
         self.splash_radius = 60  # explosion hits enemies in this radius
         self.angle = math.atan2(dy, dx)
         self.style = style
+        self.is_super = is_super
 
     def update(self, now: int):
         if not self.alive:
@@ -363,18 +365,42 @@ class ConfettiGrenade:
             # Glowing energy bolt — bright orange-white core with pulsing halo
             now = pygame.time.get_ticks()
             pulse = 0.7 + 0.3 * math.sin(now * 0.025)
-            halo_r = int(10 * pulse)
-            halo_s = pygame.Surface((halo_r * 2 + 4, halo_r * 2 + 4), pygame.SRCALPHA)
-            pygame.draw.circle(halo_s, (255, 180, 60, 80), (halo_r + 2, halo_r + 2), halo_r)
-            surface.blit(halo_s, (sx - halo_r - 2, sy - halo_r - 2))
-            pygame.draw.circle(surface, (255, 220, 100), (sx, sy), 5)
-            pygame.draw.circle(surface, (255, 255, 220), (sx, sy), 3)
-            # Trailing spark trail in direction of movement
-            trail_x = sx - int(math.cos(self.angle) * 8)
-            trail_y = sy - int(math.sin(self.angle) * 8)
-            ts = pygame.Surface((6, 6), pygame.SRCALPHA)
-            pygame.draw.circle(ts, (255, 140, 40, 140), (3, 3), 3)
-            surface.blit(ts, (trail_x - 3, trail_y - 3))
+            if self.is_super:
+                # Large super bolt: broad yellow aura + electric arc lines
+                halo_r = int((26 + 10 * pulse))
+                halo_s = pygame.Surface((halo_r * 2 + 6, halo_r * 2 + 6), pygame.SRCALPHA)
+                pygame.draw.circle(halo_s, (255, 240, 60, 90), (halo_r + 3, halo_r + 3), halo_r)
+                pygame.draw.circle(halo_s, (255, 200, 20, 50), (halo_r + 3, halo_r + 3), halo_r + 4)
+                surface.blit(halo_s, (sx - halo_r - 3, sy - halo_r - 3))
+                pygame.draw.circle(surface, (255, 230, 60), (sx, sy), 9)
+                pygame.draw.circle(surface, (255, 255, 180), (sx, sy), 5)
+                pygame.draw.circle(surface, (255, 255, 255), (sx, sy), 2)
+                # Electric arc lines radiating outward
+                arc_phase = now * 0.030
+                num_arcs = 6
+                for ai in range(num_arcs):
+                    arc_a = arc_phase + ai * (math.pi * 2 / num_arcs)
+                    arc_len = 18 + int(10 * math.sin(arc_phase * 1.7 + ai))
+                    ex = sx + int(math.cos(arc_a) * arc_len)
+                    ey = sy + int(math.sin(arc_a) * arc_len)
+                    # Zigzag midpoint
+                    mx2 = (sx + ex) // 2 + int(5 * math.sin(arc_phase * 3 + ai))
+                    my2 = (sy + ey) // 2 + int(5 * math.cos(arc_phase * 3 + ai))
+                    pygame.draw.line(surface, (255, 255, 160), (sx, sy), (mx2, my2), 2)
+                    pygame.draw.line(surface, (200, 240, 255), (mx2, my2), (ex, ey), 1)
+            else:
+                halo_r = int(10 * pulse)
+                halo_s = pygame.Surface((halo_r * 2 + 4, halo_r * 2 + 4), pygame.SRCALPHA)
+                pygame.draw.circle(halo_s, (255, 180, 60, 80), (halo_r + 2, halo_r + 2), halo_r)
+                surface.blit(halo_s, (sx - halo_r - 2, sy - halo_r - 2))
+                pygame.draw.circle(surface, (255, 220, 100), (sx, sy), 5)
+                pygame.draw.circle(surface, (255, 255, 220), (sx, sy), 3)
+                # Trailing spark trail in direction of movement
+                trail_x = sx - int(math.cos(self.angle) * 8)
+                trail_y = sy - int(math.sin(self.angle) * 8)
+                ts = pygame.Surface((6, 6), pygame.SRCALPHA)
+                pygame.draw.circle(ts, (255, 140, 40, 140), (3, 3), 3)
+                surface.blit(ts, (trail_x - 3, trail_y - 3))
         else:
             # Round grenade body
             pygame.draw.circle(surface, (80, 80, 80), (sx, sy), 6)
@@ -448,7 +474,8 @@ class PlayerProjectileSystem:
 
     def spawn_grenades(self, x: float, y: float, facing_x: float, facing_y: float,
                        damage: int, count: int = 1, speed: float = 5.5,
-                       lifetime: int = 600, splash_radius: int = 60, style: str = "confetti"):
+                       lifetime: int = 600, splash_radius: int = 60, style: str = "confetti",
+                       is_super: bool = False):
         """Spawn confetti grenades."""
         base_angle = math.atan2(facing_y, facing_x)
         for i in range(count):
@@ -456,7 +483,7 @@ class PlayerProjectileSystem:
             a = base_angle + offset
             dx = math.cos(a)
             dy = math.sin(a)
-            g = ConfettiGrenade(x, y, dx, dy, damage, style=style)
+            g = ConfettiGrenade(x, y, dx, dy, damage, style=style, is_super=is_super)
             g.speed = speed
             g.lifetime = lifetime
             g.splash_radius = splash_radius

--- a/src/systems/sounds.py
+++ b/src/systems/sounds.py
@@ -144,12 +144,15 @@ class SoundManager:
         self.sounds["throw"] = self._make_throw()
         self.sounds["chicken"] = _load_asset("chicken", volume=0.31) or self._make_chicken()
         self.sounds["confetti_boom"] = self._make_confetti_boom()
+        self.sounds["bolt_boom"] = self._make_bolt_boom()
         self.sounds["parry"] = self._make_parry()
         self.sounds["wheel_tick"] = self._make_wheel_tick()
         self.sounds["wheel_stop"] = self._make_wheel_stop()
         self.sounds["chest_open"] = self._make_chest_open()
         self.sounds["chest_fanfare"] = self._make_chest_fanfare()
         self.sounds["shield_block"] = self._make_shield_block()
+        self.sounds["plink"] = self._make_plink()
+        self.sounds["thump"] = self._make_thump()
         self.sounds["enemy_death"] = self._make_enemy_death()
         self.sounds["charge_whoosh"] = self._make_charge_whoosh()
         self.sounds["dog_bark"] = self._make_dog_bark()
@@ -177,6 +180,7 @@ class SoundManager:
             "throw":         0.30,
             "chicken":       0.31,
             "confetti_boom": 0.35,
+            "bolt_boom":     0.52,
             "parry":         0.40,
             "wheel_tick":    0.18,
             "wheel_stop":    0.40,
@@ -612,6 +616,28 @@ class SoundManager:
             buf.append(max(-32768, min(32767, sample)))
         return pygame.mixer.Sound(buffer=buf)
 
+    def _make_bolt_boom(self) -> pygame.mixer.Sound:
+        """Heavy bass thump with a sharp energy crack — explosive bolt detonation."""
+        rate = 22050
+        n = int(rate * 0.35)
+        buf = array.array("h")
+        for i in range(n):
+            t = i / rate
+            pos = i / n
+            # Sharp attack envelope — punchy front, fast decay
+            env = (1.0 - pos) ** 1.8 * min(1.0, pos * 40)
+            # Sub-bass thump — drops from 80Hz to 30Hz
+            bass = math.sin(2 * math.pi * (80 - 50 * pos) * t) * 0.5
+            bass2 = math.sin(2 * math.pi * 40 * t) * 0.25 * max(0, 1 - pos * 3)
+            # Sharp transient crack (very brief noise burst)
+            noise = (((i * 13 + 7) * 1103515245 + 12345) >> 16) & 0x7FFF
+            crack = (noise / 16384.0 - 1.0) * 0.5 * max(0, 1 - pos * 12)
+            # Short bright ring — energy discharge
+            ring = math.sin(2 * math.pi * 1200 * t) * 0.08 * max(0, 1 - pos * 6)
+            sample = int((bass + bass2 + crack + ring) * env * 32767)
+            buf.append(max(-32768, min(32767, sample)))
+        return pygame.mixer.Sound(buffer=buf)
+
     def _make_parry(self) -> pygame.mixer.Sound:
         """Satisfying metallic clang with bright ring-out."""
         rate = 22050
@@ -762,6 +788,40 @@ class SoundManager:
             noise = (((i * 19 + 11) * 1103515245 + 12345) >> 16) & 0x7FFF
             n_val = (noise / 16384.0 - 1.0) * 0.1 * max(0, 1 - pos * 4)
             sample = int((thud + ring + n_val) * env * 32767)
+            buf.append(max(-32768, min(32767, sample)))
+        return pygame.mixer.Sound(buffer=buf)
+
+    def _make_plink(self) -> pygame.mixer.Sound:
+        """Light metallic shield ping — short high-frequency ring."""
+        rate = 22050
+        n = int(rate * 0.12)
+        buf = array.array("h")
+        for i in range(n):
+            t = i / rate
+            pos = i / n
+            env = (1.0 - pos) ** 2.5
+            tone = math.sin(2 * math.pi * 3400 * t) * 0.4
+            tone += math.sin(2 * math.pi * 5200 * t) * 0.2
+            tone += math.sin(2 * math.pi * 8000 * t) * 0.08
+            sample = int(tone * env * 32767 * 0.55)
+            buf.append(max(-32768, min(32767, sample)))
+        return pygame.mixer.Sound(buffer=buf)
+
+    def _make_thump(self) -> pygame.mixer.Sound:
+        """Hollow spud-gun launch — low wobbly thwump."""
+        rate = 22050
+        n = int(rate * 0.18)
+        buf = array.array("h")
+        for i in range(n):
+            t = i / rate
+            pos = i / n
+            env = (1.0 - pos) ** 1.8 * min(1.0, pos * 20)
+            freq = 180 - pos * 80
+            tone = math.sin(2 * math.pi * freq * t) * 0.5
+            tone += math.sin(2 * math.pi * (freq * 2.1) * t) * 0.15
+            noise = (((i * 17 + 7) * 1103515245 + 12345) >> 16) & 0x7FFF
+            n_val = (noise / 16384.0 - 1.0) * 0.12 * max(0, 1 - pos * 3)
+            sample = int((tone + n_val) * env * 32767 * 0.6)
             buf.append(max(-32768, min(32767, sample)))
         return pygame.mixer.Sound(buffer=buf)
 

--- a/src/systems/status_effects.py
+++ b/src/systems/status_effects.py
@@ -12,6 +12,14 @@ STATUS_DEFS = {
         "tick_damage": 4,
         "icon": "F",
     },
+    "blue_fire": {
+        "name": "Blue Fire",
+        "color": (80, 160, 255),
+        "duration": 4000,
+        "tick_interval": 400,
+        "tick_damage": 8,
+        "icon": "B",
+    },
     "bleed": {
         "name": "Bleed",
         "color": (200, 30, 30),
@@ -151,13 +159,30 @@ class StatusManager:
         for e in self.effects:
             color = e.defn["color"]
             if e.key == "fire":
-                # Small flame particles rising — use direct draw (no SRCALPHA alloc)
-                for i in range(3):
-                    angle = (now * 0.005 + i * 2.1) % math.tau
-                    px = cx + int(math.cos(angle) * size * 0.4)
-                    py = cy + int(math.sin(angle) * size * 0.3) - int((now * 0.02 + i * 7) % 12)
-                    r = max(1, 3 - int((now * 0.01 + i * 5) % 3))
-                    pygame.draw.circle(surface, color, (px, py), r)
+                # Animated orange flames rising around enemy
+                elapsed_ratio = min(1.0, (now - e.start_time) / e.defn["duration"])
+                for i in range(5):
+                    phase = now * 0.018 + i * 1.26
+                    column_x = cx + int(math.cos(phase * 0.7) * size * 0.45)
+                    rise = int((now * 0.028 + i * 8) % (size + 8))
+                    py = cy + size // 3 - rise
+                    rad = max(1, int(4 - rise * 3 / (size + 8)))
+                    ic = int(80 + 140 * (1.0 - rise / (size + 8)))
+                    pygame.draw.circle(surface, (255, ic, 0), (column_x, py), rad)
+                    if rise < size // 3:
+                        pygame.draw.circle(surface, (255, 220, 80), (column_x, py), max(1, rad - 1))
+            elif e.key == "blue_fire":
+                # Intense blue-white plasma flames — knight super
+                for i in range(6):
+                    phase = now * 0.022 + i * 1.05
+                    cx2 = cx + int(math.cos(phase * 0.65) * size * 0.48)
+                    rise = int((now * 0.032 + i * 7) % (size + 10))
+                    py2 = cy + size // 3 - rise
+                    rad = max(1, int(5 - rise * 4 / (size + 10)))
+                    gc = int(120 + 110 * (1.0 - rise / (size + 10)))
+                    pygame.draw.circle(surface, (30, gc, 255), (cx2, py2), rad)
+                    if rise < size // 4:
+                        pygame.draw.circle(surface, (200, 230, 255), (cx2, py2), max(1, rad - 1))
             elif e.key == "bleed":
                 # Dripping red dots
                 for i in range(2):
@@ -166,12 +191,20 @@ class StatusManager:
                     py = cy + drip_y
                     pygame.draw.circle(surface, color, (px, py), 2)
             elif e.key == "poison":
-                # Green bubbles
-                for i in range(2):
-                    angle = (now * 0.003 + i * 3.14) % math.tau
-                    px = cx + int(math.cos(angle) * size * 0.5)
-                    py = cy - int((now * 0.015 + i * 20) % 16)
-                    pygame.draw.circle(surface, (*color, 140), (px, py), 2)
+                # Green toxic bubbles rising + pulsing glow ring
+                for i in range(4):
+                    angle = (now * 0.004 + i * 1.57) % math.tau
+                    orbit_r = size * 0.45 + math.sin(now * 0.006 + i) * 3
+                    px = cx + int(math.cos(angle) * orbit_r)
+                    rise = int((now * 0.02 + i * 14) % (size + 6))
+                    py = cy + size // 4 - rise
+                    bub_r = max(1, 3 - rise // max(1, size // 3))
+                    pygame.draw.circle(surface, (60, 200, 40), (px, py), bub_r)
+                    pygame.draw.circle(surface, (140, 255, 80), (px, py), max(1, bub_r - 1))
+                # Pulsing outer ring (draw with two overlapping circles to imply glow)
+                ring_r = size // 2 + int(3 * abs(math.sin(now * 0.007)))
+                pygame.draw.circle(surface, (80, 200, 40), (cx, cy), ring_r + 2, 2)
+                pygame.draw.circle(surface, (40, 120, 20), (cx, cy), ring_r, 1)
             elif e.key == "slow":
                 # Blue frost crystals
                 for i in range(3):

--- a/src/systems/status_effects.py
+++ b/src/systems/status_effects.py
@@ -160,7 +160,6 @@ class StatusManager:
             color = e.defn["color"]
             if e.key == "fire":
                 # Animated orange flames rising around enemy
-                elapsed_ratio = min(1.0, (now - e.start_time) / e.defn["duration"])
                 for i in range(5):
                     phase = now * 0.018 + i * 1.26
                     column_x = cx + int(math.cos(phase * 0.7) * size * 0.45)

--- a/src/systems/weapons.py
+++ b/src/systems/weapons.py
@@ -18,7 +18,7 @@ WEAPONS = {
         "desc": "Balanced blade. Reliable swing.",
         "class": "knight",
     },
-    "axe": {
+    "battle_axe": {
         "name": "Battle Axe",
         "damage_mult": 1.7,
         "range": 54,
@@ -42,18 +42,6 @@ WEAPONS = {
         "desc": "Spiked chain ball. Massive arc, sends enemies flying.",
         "class": "knight",
     },
-    "hammer": {
-        "name": "War Hammer",
-        "damage_mult": 2.2,
-        "range": 55,
-        "cooldown": 900,
-        "duration": 400,
-        "sweep_deg": 160,
-        "blade_color": (140, 130, 130),
-        "trail_color": (255, 120, 60),
-        "desc": "Devastating slam, very slow.",
-        "class": "knight",
-    },
     # Knight cyber upgrades
     "plasma_blade": {
         "name": "Plasma Blade",
@@ -64,8 +52,9 @@ WEAPONS = {
         "sweep_deg": 130,
         "blade_color": (0, 200, 255),
         "trail_color": (100, 220, 255),
-        "desc": "Superheated edge. Fast & deadly.",
+        "desc": "Superheated edge. Sets foes ablaze.",
         "class": "knight",
+        "on_hit_status": "fire",
     },
     "gravity_maul": {
         "name": "Gravity Maul",
@@ -112,7 +101,7 @@ WEAPONS = {
         "name": "Throwing Dagger",
         "damage_mult": 1.4,
         "range": 40,
-        "cooldown": 350,
+        "cooldown": 550,
         "duration": 120,
         "sweep_deg": 60,
         "blade_color": (180, 220, 220),
@@ -199,7 +188,7 @@ WEAPONS = {
     },
     "explosive_crossbow": {
         "name": "Explosive Crossbow",
-        "damage_mult": 2.2,
+        "damage_mult": 3.2,
         "range": 45,
         "cooldown": 900,
         "duration": 220,
@@ -209,9 +198,12 @@ WEAPONS = {
         "desc": "Explosive-tipped bolt. Arcs and detonates on impact.",
         "projectile": True,
         "grenade": True,
-        "proj_speed": 7.0,
+        "proj_speed": 8.0,
         "proj_lifetime": 700,
         "proj_count": 1,
+        "proj_style": "bolt",
+        "splash_radius": 140,
+        "sound": "bolt_boom",
         "class": "archer",
     },
     "burst_crossbow": {
@@ -270,8 +262,9 @@ WEAPONS = {
         "sweep_deg": 360,
         "blade_color": (0, 255, 255),
         "trail_color": (150, 255, 255),
-        "desc": "ZAP! Electric handshake of doom.",
+        "desc": "ZAP! Electric handshake of doom. Applies shock.",
         "class": "jester",
+        "on_hit_status": "shock",
     },
     "pie_launcher": {
         "name": "Pie Launcher",
@@ -282,12 +275,13 @@ WEAPONS = {
         "sweep_deg": 45,
         "blade_color": (255, 200, 150),
         "trail_color": (255, 255, 220),
-        "desc": "Cream pies. Deals splash damage.",
+        "desc": "Toxic cream pies. Poisons on hit.",
         "projectile": True,
         "proj_speed": 5.0,
         "proj_lifetime": 800,
         "proj_count": 1,
         "class": "jester",
+        "on_hit_status": "poison",
     },
     "confetti_grenade": {
         "name": "Confetti Grenade",
@@ -321,6 +315,24 @@ WEAPONS = {
         "orbiter_type": "box",
         "class": "jester",
     },
+    "spud_gun": {
+        "name": "Spud Gun",
+        "damage_mult": 1.6,
+        "range": 50,
+        "cooldown": 480,
+        "duration": 150,
+        "sweep_deg": 40,
+        "blade_color": (180, 140, 80),
+        "trail_color": (220, 190, 120),
+        "desc": "Launches potatoes at high velocity. Surprisingly lethal.",
+        "projectile": True,
+        "proj_speed": 8.5,
+        "proj_lifetime": 850,
+        "proj_count": 1,
+        "proj_visual": "potato",
+        "class": "jester",
+        "sound": "thump",
+    },
 }
 
 # ── Character class definitions ──
@@ -334,7 +346,7 @@ CHARACTER_CLASSES = {
         "damage_bonus": -2,
         "speed_bonus": 0,
         "knockback_bonus": 2.0,
-        "passives": ["melee_lifesteal", "armor_plating"],
+        "passives": ["melee_lifesteal"],
     },
     "archer": {
         "name": "Ranger",
@@ -344,7 +356,7 @@ CHARACTER_CLASSES = {
         "hp_bonus": 5,
         "damage_bonus": 0,
         "speed_bonus": 0.5,
-        "passives": ["crit_shots", "evasion", "nano_regen"],
+        "passives": ["evasion"],
     },
     "jester": {
         "name": "Jester",
@@ -354,7 +366,7 @@ CHARACTER_CLASSES = {
         "hp_bonus": 10,
         "damage_bonus": 0,
         "speed_bonus": 0.8,
-        "passives": ["lucky_crits", "confetti_burst", "vampiric_strike"],
+        "passives": ["lucky_crits"],
     },
 }
 
@@ -427,7 +439,7 @@ def draw_weapon(surface: pygame.Surface, sx: int, sy: int,
             _draw_grenade_idle(surface, sx, sy, sword_angle, blade_len, blade_color)
         elif "Crossbow" in wname:
             _draw_crossbow_idle(surface, sx, sy, sword_angle, blade_len, blade_color)
-        elif "Dagger" in wname or "Bow" in wname or "Rifle" in wname or "Scatter" in wname or "Banana" in wname or "Pie" in wname or "Ricochet" in wname or "Jack" in wname:
+        elif "Dagger" in wname or "Bow" in wname or "Rifle" in wname or "Scatter" in wname or "Banana" in wname or "Pie" in wname or "Ricochet" in wname or "Jack" in wname or "Spud" in wname:
             _draw_dagger_idle(surface, sx, sy, sword_angle, blade_len, blade_color)
         elif "Shield" in wname:
             _draw_shield_idle(surface, sx, sy, idle_angle, blade_len, blade_color)

--- a/src/systems/zones.py
+++ b/src/systems/zones.py
@@ -33,7 +33,7 @@ ZONES = {
     "city": {
         "name": "Ruined Metropolis",
         "desc": "Shattered skyscrapers. Something stirs below.",
-        "enemy_pool": ["cyber_zombie", "cyber_dog", "drone", "cultist", "shambler"],
+        "enemy_pool": ["cyber_zombie", "cyber_dog", "drone", "cultist", "shambler", "bulwark"],
         "mini_boss": "street_preacher",
         "boss": "eldritch_horror",
         "boss_wave": 10,
@@ -55,7 +55,7 @@ ZONES = {
     "abyss": {
         "name": "The Abyss",
         "desc": "Reality fractures. The source of corruption.",
-        "enemy_pool": ["specter", "void_wisp", "rift_walker", "mirror_shade", "gravity_warden", "null_serpent"],
+        "enemy_pool": ["specter", "void_wisp", "rift_walker", "mirror_shade", "gravity_warden", "null_serpent", "bulwark"],
         "mini_boss": "architect",
         "boss": "nexus",
         "boss_wave": 10,

--- a/src/ui/hud.py
+++ b/src/ui/hud.py
@@ -91,78 +91,116 @@ class HUD:
         surface.blit(num_surf, (bar_x + bar_w // 2 - num_surf.get_width() // 2, bar_y - 14))
 
     def _draw_energy_bar(self, surface: pygame.Surface, player):
-        """Horizontal energy bar under the HP bar. Gold border, fireworks when full."""
+        """Segmented super energy bar — 12 pips, colour-shifts amber→gold→white-hot when full."""
         bar_x, bar_y = 20, 48
-        bar_w, bar_h = 220, 16
+        bar_w, bar_h = 220, 20
         energy = getattr(player, "energy", 0)
-        max_energy = getattr(player, "max_energy", 100)
+        max_energy = getattr(player, "max_energy", 120)
         ratio = min(1.0, energy / max_energy) if max_energy > 0 else 0
         now = pygame.time.get_ticks()
         ready = energy >= max_energy
-        flash_on = ready and (now // 80) % 2 == 0   # faster flash
+        flash_on = ready and (now // 70) % 2 == 0
 
-        # Subtle golden edge vignette when super is ready
+        # ── Golden edge vignette when super is ready ──────────────────────────
         if ready:
-            edge_pulse = int(28 + 18 * math.sin(now * 0.006))
-            vig = pygame.Surface((SCREEN_WIDTH, SCREEN_HEIGHT), pygame.SRCALPHA)
-            for t in range(14):
-                a = max(0, edge_pulse - t * 3)
-                pygame.draw.rect(vig, (255, 200, 0, a),
+            pulse_a = int(22 + 14 * abs(math.sin(now * 0.005)))
+            if not hasattr(self, '_vig_surf') or self._vig_surf is None:
+                self._vig_surf = pygame.Surface((SCREEN_WIDTH, SCREEN_HEIGHT), pygame.SRCALPHA)
+            self._vig_surf.fill((0, 0, 0, 0))
+            for t in range(12):
+                a = max(0, pulse_a - t * 3)
+                pygame.draw.rect(self._vig_surf, (255, 190, 0, a),
                                  (t, t, SCREEN_WIDTH - t * 2, SCREEN_HEIGHT - t * 2), 1)
-            surface.blit(vig, (0, 0))
-
-        # Background
-        pygame.draw.rect(surface, (25, 18, 0), (bar_x, bar_y, bar_w, bar_h))
-
-        # Fill
-        fill_w = int(bar_w * ratio)
-        if fill_w > 0:
-            if ready:
-                fill_c = (255, 255, 100) if flash_on else (255, 200, 0)
-            else:
-                r = min(255, 160 + int(95 * ratio))
-                g = min(255, 80 + int(100 * ratio))
-                fill_c = (r, g, 0)
-            pygame.draw.rect(surface, fill_c, (bar_x, bar_y, fill_w, bar_h))
-
-        # Border
-        if ready:
-            pulse = int(55 * abs(math.sin(now * 0.010)))
-            border_c = (255, min(255, 200 + pulse), 0)
-            # Thick glowing border
-            pygame.draw.rect(surface, border_c, (bar_x - 2, bar_y - 2, bar_w + 4, bar_h + 4), 3)
-            pygame.draw.rect(surface, (255, 255, 255), (bar_x, bar_y, bar_w, bar_h), 1)
+            surface.blit(self._vig_surf, (0, 0))
         else:
-            pygame.draw.rect(surface, (160, 110, 10), (bar_x, bar_y, bar_w, bar_h), 1)
+            self._vig_surf = None   # free when not needed
 
-        # Tall flame ripple above bar when full — reuse cached surface each frame
+        # ── Segmented pip bar ─────────────────────────────────────────────────
+        num_segs = 12
+        gap = 2
+        seg_w = (bar_w - gap * (num_segs - 1)) // num_segs
+        filled_segs = int(ratio * num_segs)         # whole pips
+        partial = (ratio * num_segs) % 1.0          # sub-pip fill
+
+        for i in range(num_segs):
+            px = bar_x + i * (seg_w + gap)
+            py = bar_y
+
+            # Segment state
+            if i < filled_segs:
+                seg_fill = 1.0
+            elif i == filled_segs:
+                seg_fill = partial
+            else:
+                seg_fill = 0.0
+
+            # Background of segment
+            pygame.draw.rect(surface, (28, 18, 4), (px, py, seg_w, bar_h), border_radius=3)
+
+            if seg_fill > 0:
+                fw = max(3, int(seg_w * seg_fill))
+                if ready:
+                    pulse = abs(math.sin(now * 0.012 + i * 0.4))
+                    r = 255
+                    g = int(200 + 55 * pulse)
+                    b = int(40 * pulse)
+                    fill_c = (r, min(255, g), b)
+                elif ratio > 0.75:
+                    fill_c = (255, int(160 + 95 * ratio), 0)
+                else:
+                    fill_c = (int(180 + 75 * ratio), int(80 + 80 * ratio), 0)
+                pygame.draw.rect(surface, fill_c, (px, py, fw, bar_h), border_radius=3)
+
+                # Highlight stripe on top of filled pip
+                hl_a = int(60 + 40 * seg_fill)
+                hl_surf = pygame.Surface((fw, 3), pygame.SRCALPHA)
+                hl_surf.fill((255, 255, 255, hl_a))
+                surface.blit(hl_surf, (px, py + 1))
+
+            # Segment border
+            if ready:
+                pulse2 = abs(math.sin(now * 0.010 + i * 0.5))
+                bc = (255, int(180 + 75 * pulse2), 0)
+                pygame.draw.rect(surface, bc, (px, py, seg_w, bar_h), 1, border_radius=3)
+            else:
+                pygame.draw.rect(surface, (90, 60, 8), (px, py, seg_w, bar_h), 1, border_radius=3)
+
+        # ── Flame ripple above bar when full ──────────────────────────────────
         if ready:
-            _flame_h = 20
+            _flame_h = 22
             if self._flame_surf is None or self._flame_surf_w != bar_w:
                 self._flame_surf = pygame.Surface((bar_w, _flame_h), pygame.SRCALPHA)
                 self._flame_surf_w = bar_w
             self._flame_surf.fill((0, 0, 0, 0))
-            for i in range(0, bar_w, 4):
-                flicker = math.sin(now * 0.011 + i * 0.35)
-                fh = int(5 + 9 * abs(flicker))
-                g_c = int(60 + 160 * abs(flicker))
+            for i in range(0, bar_w, 3):
+                flicker = math.sin(now * 0.013 + i * 0.32)
+                fh = int(6 + 12 * abs(flicker))
+                gc = int(80 + 150 * abs(flicker))
+                bc2 = int(20 * abs(flicker))
                 for row in range(fh):
-                    alpha = int(255 * (1.0 - row / (fh + 1)))
-                    pygame.draw.rect(self._flame_surf, (255, g_c, 0, alpha), (i, row, 4, 1))
-            surface.blit(self._flame_surf, (bar_x, bar_y - _flame_h + 4))
+                    alpha = int(230 * (1.0 - row / (fh + 1)))
+                    pygame.draw.rect(self._flame_surf, (255, gc, bc2, alpha), (i, row, 3, 1))
+            surface.blit(self._flame_surf, (bar_x, bar_y - _flame_h + 5))
 
-        # Label — big bold flashing when ready
+        # ── Label ─────────────────────────────────────────────────────────────
         if ready:
-            lbl_color = (255, 255, 255) if flash_on else (255, 220, 0)
+            lbl_color = (255, 255, 255) if flash_on else (255, 215, 0)
             lbl = self.font.render("⚡ SUPER READY ⚡", True, lbl_color)
-            # Shadow
-            shadow = self.font.render("⚡ SUPER READY ⚡", True, (80, 40, 0))
-            lx = bar_x + bar_w // 2 - lbl.get_width() // 2
-            surface.blit(shadow, (lx + 2, bar_y + 2))
-            surface.blit(lbl, (lx, bar_y))
+            shadow = self.font.render("⚡ SUPER READY ⚡", True, (70, 35, 0))
+            # Scale up slightly for drama
+            scale = 1.0 + 0.06 * abs(math.sin(now * 0.008))
+            scaled_w = max(lbl.get_width(), int(lbl.get_width() * scale))
+            scaled_h = max(lbl.get_height(), int(lbl.get_height() * scale))
+            lbl_scaled = pygame.transform.scale(lbl, (scaled_w, scaled_h))
+            shadow_scaled = pygame.transform.scale(shadow, (scaled_w, scaled_h))
+            lx = bar_x + bar_w // 2 - scaled_w // 2
+            surface.blit(shadow_scaled, (lx + 2, bar_y + 2))
+            surface.blit(lbl_scaled, (lx, bar_y))
         else:
-            e_lbl = self.font_small.render(f"ENERGY  {energy}/{max_energy}", True, (140, 100, 10))
-            surface.blit(e_lbl, (bar_x + 4, bar_y + 1))
+            filled_count = int(ratio * num_segs)
+            e_lbl = self.font_small.render(
+                f"SUPER  {filled_count}/{num_segs}", True, (150, 105, 15))
+            surface.blit(e_lbl, (bar_x + 4, bar_y + 3))
 
 
     def _draw_info(self, surface: pygame.Surface, player, wave: int, enemy_count: int,

--- a/src/ui/hud.py
+++ b/src/ui/hud.py
@@ -15,9 +15,7 @@ class HUD:
         self.font = pygame.font.SysFont("consolas", 20)
         self.font_big = pygame.font.SysFont("consolas", 36)
         self.font_small = pygame.font.SysFont("consolas", 14)
-        # Cached energy flame surface — rebuilt only when bar width changes
-        self._flame_surf: pygame.Surface | None = None
-        self._flame_surf_w: int = 0
+        self._vig_surf: pygame.Surface | None = None
 
     def draw(self, surface: pygame.Surface, player, wave: int, enemy_count: int,
              darkness: float = 0.0, boss_wave: bool = False, boss_enemies: list = None):
@@ -91,103 +89,85 @@ class HUD:
         surface.blit(num_surf, (bar_x + bar_w // 2 - num_surf.get_width() // 2, bar_y - 14))
 
     def _draw_energy_bar(self, surface: pygame.Surface, player):
-        """Segmented super energy bar — 12 pips, colour-shifts amber→gold→white-hot when full."""
+        """Super energy bar — solid fill, amber→gold, electric arcs when ready."""
         bar_x, bar_y = 20, 48
-        bar_w, bar_h = 220, 20
+        bar_w, bar_h = 220, 18
         energy = getattr(player, "energy", 0)
         max_energy = getattr(player, "max_energy", 120)
         ratio = min(1.0, energy / max_energy) if max_energy > 0 else 0
         now = pygame.time.get_ticks()
         ready = energy >= max_energy
-        flash_on = ready and (now // 70) % 2 == 0
 
-        # ── Golden edge vignette when super is ready ──────────────────────────
+        # ── Edge vignette when super is ready — alternates gold/blue ─────────
         if ready:
             pulse_a = int(22 + 14 * abs(math.sin(now * 0.005)))
             if not hasattr(self, '_vig_surf') or self._vig_surf is None:
                 self._vig_surf = pygame.Surface((SCREEN_WIDTH, SCREEN_HEIGHT), pygame.SRCALPHA)
             self._vig_surf.fill((0, 0, 0, 0))
+            flash_blue = (now // 120) % 2 == 0
             for t in range(12):
                 a = max(0, pulse_a - t * 3)
-                pygame.draw.rect(self._vig_surf, (255, 190, 0, a),
+                col = (80, 200, 255, a) if flash_blue else (255, 210, 0, a)
+                pygame.draw.rect(self._vig_surf, col,
                                  (t, t, SCREEN_WIDTH - t * 2, SCREEN_HEIGHT - t * 2), 1)
             surface.blit(self._vig_surf, (0, 0))
         else:
-            self._vig_surf = None   # free when not needed
+            self._vig_surf = None
 
-        # ── Segmented pip bar ─────────────────────────────────────────────────
-        num_segs = 12
-        gap = 2
-        seg_w = (bar_w - gap * (num_segs - 1)) // num_segs
-        filled_segs = int(ratio * num_segs)         # whole pips
-        partial = (ratio * num_segs) % 1.0          # sub-pip fill
+        # ── Background ────────────────────────────────────────────────────────
+        pygame.draw.rect(surface, (25, 14, 0), (bar_x - 1, bar_y - 1, bar_w + 2, bar_h + 2),
+                         border_radius=4)
+        pygame.draw.rect(surface, (28, 16, 0), (bar_x, bar_y, bar_w, bar_h), border_radius=3)
 
-        for i in range(num_segs):
-            px = bar_x + i * (seg_w + gap)
-            py = bar_y
-
-            # Segment state
-            if i < filled_segs:
-                seg_fill = 1.0
-            elif i == filled_segs:
-                seg_fill = partial
-            else:
-                seg_fill = 0.0
-
-            # Background of segment
-            pygame.draw.rect(surface, (28, 18, 4), (px, py, seg_w, bar_h), border_radius=3)
-
-            if seg_fill > 0:
-                fw = max(3, int(seg_w * seg_fill))
-                if ready:
-                    pulse = abs(math.sin(now * 0.012 + i * 0.4))
-                    r = 255
-                    g = int(200 + 55 * pulse)
-                    b = int(40 * pulse)
-                    fill_c = (r, min(255, g), b)
-                elif ratio > 0.75:
-                    fill_c = (255, int(160 + 95 * ratio), 0)
-                else:
-                    fill_c = (int(180 + 75 * ratio), int(80 + 80 * ratio), 0)
-                pygame.draw.rect(surface, fill_c, (px, py, fw, bar_h), border_radius=3)
-
-                # Highlight stripe on top of filled pip
-                hl_a = int(60 + 40 * seg_fill)
-                hl_surf = pygame.Surface((fw, 3), pygame.SRCALPHA)
-                hl_surf.fill((255, 255, 255, hl_a))
-                surface.blit(hl_surf, (px, py + 1))
-
-            # Segment border
+        # ── Filled portion ────────────────────────────────────────────────────
+        fill_w = int(bar_w * ratio)
+        if fill_w > 0:
             if ready:
-                pulse2 = abs(math.sin(now * 0.010 + i * 0.5))
-                bc = (255, int(180 + 75 * pulse2), 0)
-                pygame.draw.rect(surface, bc, (px, py, seg_w, bar_h), 1, border_radius=3)
+                pulse = 0.5 + 0.5 * abs(math.sin(now * 0.010))
+                r, g, b = 255, int(215 + 40 * pulse), int(60 * pulse)
+            elif ratio > 0.7:
+                r, g, b = 255, int(150 + 100 * ratio), 0
             else:
-                pygame.draw.rect(surface, (90, 60, 8), (px, py, seg_w, bar_h), 1, border_radius=3)
+                r, g, b = int(180 + 75 * ratio), int(80 + 80 * ratio), 0
+            pygame.draw.rect(surface, (r, g, b), (bar_x, bar_y, fill_w, bar_h), border_radius=3)
+            # Highlight stripe on top
+            hl = pygame.Surface((fill_w, 4), pygame.SRCALPHA)
+            hl.fill((255, 255, 255, 50))
+            surface.blit(hl, (bar_x, bar_y + 1))
 
-        # ── Flame ripple above bar when full ──────────────────────────────────
+        # ── Border ────────────────────────────────────────────────────────────
+        border_col = (255, 220, 0) if ready else (90, 55, 8)
+        pygame.draw.rect(surface, border_col, (bar_x, bar_y, bar_w, bar_h), 2, border_radius=3)
+
+        # ── Electric arcs when ready ──────────────────────────────────────────
         if ready:
-            _flame_h = 22
-            if self._flame_surf is None or self._flame_surf_w != bar_w:
-                self._flame_surf = pygame.Surface((bar_w, _flame_h), pygame.SRCALPHA)
-                self._flame_surf_w = bar_w
-            self._flame_surf.fill((0, 0, 0, 0))
-            for i in range(0, bar_w, 3):
-                flicker = math.sin(now * 0.013 + i * 0.32)
-                fh = int(6 + 12 * abs(flicker))
-                gc = int(80 + 150 * abs(flicker))
-                bc2 = int(20 * abs(flicker))
-                for row in range(fh):
-                    alpha = int(230 * (1.0 - row / (fh + 1)))
-                    pygame.draw.rect(self._flame_surf, (255, gc, bc2, alpha), (i, row, 3, 1))
-            surface.blit(self._flame_surf, (bar_x, bar_y - _flame_h + 5))
+            for arc_i in range(2):
+                phase = now * 0.020 + arc_i * 3.9
+                pts = []
+                steps = 24
+                for s in range(steps + 1):
+                    ax = bar_x + int(bar_w * s / steps)
+                    amp = 5 + 3 * arc_i
+                    ay = bar_y - 3 - arc_i * 5 + int(amp * math.sin(phase + s * 0.65))
+                    pts.append((ax, ay))
+                if len(pts) > 1:
+                    arc_col = (160, 220, 255) if arc_i == 0 else (255, 255, 255)
+                    pygame.draw.lines(surface, arc_col, False, pts, 1)
+            # Bright spark nodes along the arc
+            for i in range(0, bar_w + 1, 30):
+                phase2 = now * 0.022 + i * 0.14
+                spy = bar_y - 4 + int(5 * math.sin(phase2))
+                a2 = 180 + int(75 * abs(math.sin(phase2)))
+                ss = pygame.Surface((6, 6), pygame.SRCALPHA)
+                pygame.draw.circle(ss, (255, 255, 200, a2), (3, 3), 2)
+                surface.blit(ss, (bar_x + i - 3, spy - 3))
 
         # ── Label ─────────────────────────────────────────────────────────────
         if ready:
+            flash_on = (now // 70) % 2 == 0
             lbl_color = (255, 255, 255) if flash_on else (255, 215, 0)
             lbl = self.font.render("⚡ SUPER READY ⚡", True, lbl_color)
             shadow = self.font.render("⚡ SUPER READY ⚡", True, (70, 35, 0))
-            # Scale up slightly for drama
             scale = 1.0 + 0.06 * abs(math.sin(now * 0.008))
             scaled_w = max(lbl.get_width(), int(lbl.get_width() * scale))
             scaled_h = max(lbl.get_height(), int(lbl.get_height() * scale))
@@ -197,10 +177,9 @@ class HUD:
             surface.blit(shadow_scaled, (lx + 2, bar_y + 2))
             surface.blit(lbl_scaled, (lx, bar_y))
         else:
-            filled_count = int(ratio * num_segs)
-            e_lbl = self.font_small.render(
-                f"SUPER  {filled_count}/{num_segs}", True, (150, 105, 15))
-            surface.blit(e_lbl, (bar_x + 4, bar_y + 3))
+            pct = int(ratio * 100)
+            e_lbl = self.font_small.render(f"SUPER  {pct}%", True, (150, 105, 15))
+            surface.blit(e_lbl, (bar_x + 4, bar_y + 2))
 
 
     def _draw_info(self, surface: pygame.Surface, player, wave: int, enemy_count: int,

--- a/src/ui/hud.py
+++ b/src/ui/hud.py
@@ -15,6 +15,9 @@ class HUD:
         self.font = pygame.font.SysFont("consolas", 20)
         self.font_big = pygame.font.SysFont("consolas", 36)
         self.font_small = pygame.font.SysFont("consolas", 14)
+        # Cached energy flame surface — rebuilt only when bar width changes
+        self._flame_surf: pygame.Surface | None = None
+        self._flame_surf_w: int = 0
 
     def draw(self, surface: pygame.Surface, player, wave: int, enemy_count: int,
              darkness: float = 0.0, boss_wave: bool = False, boss_enemies: list = None):
@@ -132,18 +135,21 @@ class HUD:
         else:
             pygame.draw.rect(surface, (160, 110, 10), (bar_x, bar_y, bar_w, bar_h), 1)
 
-        # Tall flame ripple above bar when full
+        # Tall flame ripple above bar when full — reuse cached surface each frame
         if ready:
             _flame_h = 20
-            flame_surf = pygame.Surface((bar_w, _flame_h), pygame.SRCALPHA)
+            if self._flame_surf is None or self._flame_surf_w != bar_w:
+                self._flame_surf = pygame.Surface((bar_w, _flame_h), pygame.SRCALPHA)
+                self._flame_surf_w = bar_w
+            self._flame_surf.fill((0, 0, 0, 0))
             for i in range(0, bar_w, 4):
                 flicker = math.sin(now * 0.011 + i * 0.35)
                 fh = int(5 + 9 * abs(flicker))
                 g_c = int(60 + 160 * abs(flicker))
                 for row in range(fh):
                     alpha = int(255 * (1.0 - row / (fh + 1)))
-                    pygame.draw.rect(flame_surf, (255, g_c, 0, alpha), (i, row, 4, 1))
-            surface.blit(flame_surf, (bar_x, bar_y - _flame_h + 4))
+                    pygame.draw.rect(self._flame_surf, (255, g_c, 0, alpha), (i, row, 4, 1))
+            surface.blit(self._flame_surf, (bar_x, bar_y - _flame_h + 4))
 
         # Label — big bold flashing when ready
         if ready:

--- a/src/ui/icons.py
+++ b/src/ui/icons.py
@@ -289,9 +289,8 @@ def _pi_confetti(s, cx, cy, sz, c):
 def _draw_weapon_icon(surf: pygame.Surface, key: str, sz: int):
     _fn = {
         "sword":            _wi_sword,
-        "axe":              _wi_axe,
+        "battle_axe":       _wi_axe,
         "spear":            _wi_spear,
-        "hammer":           _wi_hammer,
         "plasma_blade":     _wi_plasma_blade,
         "gravity_maul":     _wi_gravity_maul,
         "blade_barrier":    _wi_blade_barrier,
@@ -307,6 +306,7 @@ def _draw_weapon_icon(surf: pygame.Surface, key: str, sz: int):
         "pie_launcher":     _wi_pie_launcher,
         "confetti_grenade": _wi_confetti_grenade,
         "jack_in_box":      _wi_jack_in_box,
+        "spud_gun":         _wi_spud_gun,
     }.get(key)
     if _fn:
         _fn(surf, sz // 2, sz // 2, sz)
@@ -625,3 +625,21 @@ def _wi_jack_in_box(s, cx, cy, sz):
            (cx, cy - 10 - r * 2 // 3),
            (cx + r // 3, cy - 10 - r // 3)]
     pygame.draw.polygon(s, bc, pts)
+
+
+def _wi_spud_gun(s, cx, cy, sz):
+    """Potato gun — barrel + lumpy potato projectile."""
+    r = sz // 2 - 2
+    # Barrel (pipe)
+    barrel_len = r
+    pygame.draw.rect(s, (120, 90, 50), (cx - barrel_len // 2, cy - 3, barrel_len, 6))
+    pygame.draw.rect(s, (80, 60, 30), (cx - barrel_len // 2, cy - 3, barrel_len, 6), 1)
+    # Stock/handle
+    pygame.draw.rect(s, (100, 75, 40), (cx - barrel_len // 2, cy + 3, barrel_len // 2, 5))
+    # Potato lump (oval) at muzzle
+    potato_x = cx + barrel_len // 2 + 4
+    pygame.draw.ellipse(s, (180, 145, 80), (potato_x - 5, cy - 4, 10, 9))
+    pygame.draw.ellipse(s, (140, 110, 55), (potato_x - 5, cy - 4, 10, 9), 1)
+    # Potato eyes (two tiny dots)
+    pygame.draw.circle(s, (100, 70, 30), (potato_x - 1, cy - 1), 1)
+    pygame.draw.circle(s, (100, 70, 30), (potato_x + 2, cy + 1), 1)

--- a/src/ui/levelup.py
+++ b/src/ui/levelup.py
@@ -122,7 +122,8 @@ WEAPON_UPGRADES: dict[str, list[dict]] = {
     "jack_in_box": [
         {"name": "Spring Loaded",  "icon": "C", "color": (200, 80, 255),  "effect": "cooldown", "value": 70, "desc": "-70ms cooldown — faster spring"},
         {"name": "Pop Goes Boom",  "icon": "D", "color": (180, 60, 220),  "effect": "damage",   "value": 12, "desc": "+12 damage — surprise explosion"},
-    ],    "spud_gun": [
+    ],
+    "spud_gun": [
         {"name": "Starch Rounds",  "icon": "D", "color": (180, 140, 60),  "effect": "damage",   "value": 11, "desc": "+11 damage \u2014 heavyweight potatoes"},
         {"name": "Spud Salvo",     "icon": "C", "color": (160, 120, 50),  "effect": "cooldown", "value": 65, "desc": "-65ms cooldown \u2014 rapid-fire spuds"},
     ],}

--- a/src/ui/levelup.py
+++ b/src/ui/levelup.py
@@ -26,12 +26,12 @@ LEVEL_UPGRADES = [
     {"name": "Explosive Kills", "icon": "E", "color": (255, 150, 0),   "effect": "passive", "value": "explosive_kills", "desc": "25% chance for enemies to explode on death"},
     {"name": "Magnetic Field",  "icon": "F", "color": (150, 150, 255), "effect": "passive", "value": "magnetic_field",  "desc": "ALL pickups fly to you from much further away"},
     {"name": "Adrenaline Rush", "icon": "A", "color": (0, 255, 100),   "effect": "passive", "value": "adrenaline",      "desc": "+30% speed for 3s after each kill"},
-    {"name": "Rapid Dash",      "icon": ">", "color": (100, 220, 255), "effect": "dash_charges", "value": 1, "desc": "+1 dash charge before cooldown (max 2 total)"},
+    {"name": "Rapid Dash",      "icon": ">", "color": (100, 220, 255), "effect": "dash_charges", "value": 1, "desc": "+1 dash charge before cooldown (max 4 total)"},
     {"name": "Armor Plating",   "icon": "M", "color": (120, 180, 255), "effect": "passive", "value": "armor_plating",   "desc": "Take 15% less damage from all sources"},
     {"name": "Critical Shots",   "icon": "!", "color": (255, 200, 50),  "effect": "passive", "value": "crit_shots",     "class_restrict": ["archer", "jester"], "desc": "20% chance for double damage on projectiles. Not available to Knight."},
     {"name": "Melee Lifesteal",   "icon": "K", "color": (255, 80, 80),   "effect": "passive", "value": "melee_lifesteal", "class_restrict": ["knight", "jester"], "desc": "Heal 2 HP on melee kills. Not available to Ranger."},
-    {"name": "Confetti Burst",   "icon": "E", "color": (255, 100, 255), "effect": "passive", "value": "confetti_burst", "desc": "Kills have 20% chance to stun nearby enemies"},
-    {"name": "Parry Deflect",   "icon": "P", "color": (200, 255, 180), "effect": "passive", "value": "parry_deflect", "class_restrict": "archer", "desc": "Parried bullets fire back at nearest enemy (2x damage). Ranger only."},
+    {"name": "Confetti Burst",   "icon": "E", "color": (255, 100, 255), "effect": "passive", "value": "confetti_burst", "class_restrict": "jester", "desc": "Kills have 20% chance to stun nearby enemies"},
+    {"name": "Parry Deflect",   "icon": "P", "color": (200, 255, 180), "effect": "passive", "value": "parry_deflect", "class_restrict": "knight", "desc": "Parried bullets fire back at nearest enemy (2x damage). Knight only."},
 ]
 
 
@@ -342,19 +342,21 @@ class LevelUpScreen:
             icon = self.font_big.render(choice["icon"], True, icon_color)
             surface.blit(icon, (cx + 50, cy + 18))
 
-            # Name
+            # Name — centered in the right text area (cx+90 .. cx+card_w-10)
+            text_x = cx + 90
+            text_w = card_w - 100
             name = self.font.render(choice["name"], True, WHITE)
-            surface.blit(name, (cx + 95, cy + 18))
+            name_x = text_x + (text_w - name.get_width()) // 2
+            surface.blit(name, (max(text_x, name_x), cy + 18))
 
-            # Description — word-wrap to fit card width
+            # Description — pixel-width word-wrap, each line centered
             desc = choice.get("desc", "")
             if desc:
-                # Break into lines of ~34 chars so they fit the ~255px available space
                 words = desc.split()
                 lines, line_buf = [], []
                 for word in words:
                     test = " ".join(line_buf + [word])
-                    if len(test) > 34 and line_buf:
+                    if self.font_small.size(test)[0] > text_w and line_buf:
                         lines.append(" ".join(line_buf))
                         line_buf = [word]
                     else:
@@ -363,7 +365,8 @@ class LevelUpScreen:
                     lines.append(" ".join(line_buf))
                 for li, line_text in enumerate(lines[:2]):
                     dl = self.font_small.render(line_text, True, (160, 160, 160))
-                    surface.blit(dl, (cx + 95, cy + 46 + li * 16))
+                    dl_x = text_x + (text_w - dl.get_width()) // 2
+                    surface.blit(dl, (max(text_x, dl_x), cy + 46 + li * 16))
 
             # Type tag
             ctype = choice.get("type", "stat")
@@ -382,8 +385,8 @@ class LevelUpScreen:
             # Passives full warning on passive choices
             if self._passives_full and choice.get("effect") == "passive":
                 warn_color = (255, 180, 50)
-                warn_text = self.font_small.render("\u26a0 SLOTS FULL — SWAP", True, warn_color)
-                wx = cx + 95
+                warn_text = self.font_small.render("\u26a0 SLOTS FULL \u2014 SWAP", True, warn_color)
+                wx = text_x + (text_w - warn_text.get_width()) // 2
                 wy = cy + 80
                 pygame.draw.rect(surface, (60, 40, 10), (wx - 3, wy - 1, warn_text.get_width() + 6, warn_text.get_height() + 2), border_radius=3)
                 surface.blit(warn_text, (wx, wy))

--- a/src/ui/levelup.py
+++ b/src/ui/levelup.py
@@ -26,7 +26,11 @@ LEVEL_UPGRADES = [
     {"name": "Explosive Kills", "icon": "E", "color": (255, 150, 0),   "effect": "passive", "value": "explosive_kills", "desc": "25% chance for enemies to explode on death"},
     {"name": "Magnetic Field",  "icon": "F", "color": (150, 150, 255), "effect": "passive", "value": "magnetic_field",  "desc": "ALL pickups fly to you from much further away"},
     {"name": "Adrenaline Rush", "icon": "A", "color": (0, 255, 100),   "effect": "passive", "value": "adrenaline",      "desc": "+30% speed for 3s after each kill"},
-    {"name": "Rapid Dash",      "icon": ">", "color": (100, 220, 255), "effect": "dash_charges", "value": 1, "desc": "+1 dash charge before cooldown (stack up to 4 total)"},
+    {"name": "Rapid Dash",      "icon": ">", "color": (100, 220, 255), "effect": "dash_charges", "value": 1, "desc": "+1 dash charge before cooldown (max 2 total)"},
+    {"name": "Armor Plating",   "icon": "M", "color": (120, 180, 255), "effect": "passive", "value": "armor_plating",   "desc": "Take 15% less damage from all sources"},
+    {"name": "Critical Shots",   "icon": "!", "color": (255, 200, 50),  "effect": "passive", "value": "crit_shots",     "class_restrict": ["archer", "jester"], "desc": "20% chance for double damage on projectiles. Not available to Knight."},
+    {"name": "Melee Lifesteal",   "icon": "K", "color": (255, 80, 80),   "effect": "passive", "value": "melee_lifesteal", "class_restrict": ["knight", "jester"], "desc": "Heal 2 HP on melee kills. Not available to Ranger."},
+    {"name": "Confetti Burst",   "icon": "E", "color": (255, 100, 255), "effect": "passive", "value": "confetti_burst", "desc": "Kills have 20% chance to stun nearby enemies"},
     {"name": "Parry Deflect",   "icon": "P", "color": (200, 255, 180), "effect": "passive", "value": "parry_deflect", "class_restrict": "archer", "desc": "Parried bullets fire back at nearest enemy (2x damage). Ranger only."},
 ]
 
@@ -40,7 +44,7 @@ WEAPON_UPGRADES: dict[str, list[dict]] = {
         {"name": "Flame Slash",    "icon": "D", "color": (255, 120, 30),  "effect": "damage",   "value": 12, "desc": "+12 damage — burning sword strikes"},
         {"name": "Strike Tempo",   "icon": "C", "color": (255, 180, 80),  "effect": "cooldown", "value": 70, "desc": "-70ms cooldown — faster swing rhythm"},
     ],
-    "axe": [
+    "battle_axe": [
         {"name": "Cleaving Arc",   "icon": "R", "color": (200, 80, 50),   "effect": "range",    "value": 18, "desc": "+18 range — wider axe arc"},
         {"name": "Executioner",    "icon": "D", "color": (220, 60, 40),   "effect": "damage",   "value": 14, "desc": "+14 damage — decapitating blow"},
     ],
@@ -48,10 +52,7 @@ WEAPON_UPGRADES: dict[str, list[dict]] = {
         {"name": "Chain Momentum", "icon": "D", "color": (220, 190, 90),  "effect": "damage",   "value": 12, "desc": "+12 damage — spiked ball gathers momentum"},
         {"name": "Whip Extension", "icon": "R", "color": (200, 175, 120), "effect": "range",    "value": 16, "desc": "+16 range — longer chain, wider arc"},
     ],
-    "hammer": [
-        {"name": "Shockwave",      "icon": "D", "color": (255, 220, 50),  "effect": "damage",   "value": 16, "desc": "+16 damage — hammer shockwave"},
-        {"name": "Tectonic Force", "icon": "R", "color": (200, 150, 50),  "effect": "range",    "value": 20, "desc": "+20 range — ground-crack radius"},
-    ],
+
     "plasma_blade": [
         {"name": "Plasma Overcharge","icon":"C", "color": (0, 255, 200),  "effect": "cooldown", "value": 80, "desc": "-80ms cooldown — rapid plasma cuts"},
         {"name": "Thermal Edge",   "icon": "D", "color": (0, 200, 255),   "effect": "damage",   "value": 12, "desc": "+12 damage — superheated edge"},
@@ -121,8 +122,10 @@ WEAPON_UPGRADES: dict[str, list[dict]] = {
     "jack_in_box": [
         {"name": "Spring Loaded",  "icon": "C", "color": (200, 80, 255),  "effect": "cooldown", "value": 70, "desc": "-70ms cooldown — faster spring"},
         {"name": "Pop Goes Boom",  "icon": "D", "color": (180, 60, 220),  "effect": "damage",   "value": 12, "desc": "+12 damage — surprise explosion"},
-    ],
-}
+    ],    "spud_gun": [
+        {"name": "Starch Rounds",  "icon": "D", "color": (180, 140, 60),  "effect": "damage",   "value": 11, "desc": "+11 damage \u2014 heavyweight potatoes"},
+        {"name": "Spud Salvo",     "icon": "C", "color": (160, 120, 50),  "effect": "cooldown", "value": 65, "desc": "-65ms cooldown \u2014 rapid-fire spuds"},
+    ],}
 
 
 class LevelUpScreen:
@@ -156,8 +159,11 @@ class LevelUpScreen:
 
         # Add stat + passive upgrades (filter out already-owned passives, maxed tiers, and class-restricted upgrades)
         for u in LEVEL_UPGRADES:
-            if u.get("class_restrict") and u["class_restrict"] != player_class:
-                continue
+            cr = u.get("class_restrict")
+            if cr:
+                allowed = cr if isinstance(cr, list) else [cr]
+                if player_class not in allowed:
+                    continue
             if u["effect"] == "passive" and u["value"] in owned:
                 continue
             if u["effect"] == "glass_cannon" and "glass_cannon" in owned:

--- a/src/ui/levelup.py
+++ b/src/ui/levelup.py
@@ -244,13 +244,16 @@ class LevelUpScreen:
 
         # ── Weighted 3-choice selection ──────────────────────────────────────
         # Separate pool into categories for intentional representation.
-        # When passive slots are full: no passive offers (stops swap-screen spam).
+        # When passive slots are full: passives can still appear but at low chance
+        # so the player can swap one in — they just won't dominate all 3 slots.
         stat_pool    = [e for e in pool
                         if e.get("type") == "stat" and e.get("effect") != "passive"]
-        passive_pool = ([] if self._passives_full
-                        else [e for e in pool if e.get("effect") == "passive"])
+        passive_pool = [e for e in pool if e.get("effect") == "passive"]
         weapon_pool  = [e for e in pool
                         if e.get("type") in ("weapon", "weapon_upgrade")]
+
+        # Passive chance: 55% when slots available, 18% when full (rare swap offer)
+        passive_chance = 0.18 if self._passives_full else 0.55
 
         chosen: list[dict] = []
         chosen_ids: set[int] = set()
@@ -271,16 +274,20 @@ class LevelUpScreen:
         else:
             _take(stat_pool) or _take(weapon_pool)
 
-        # Slot 2 — passive if available (55% chance) or stat/weapon otherwise
-        if passive_pool and random.random() < 0.55:
+        # Slot 2 — passive (at passive_chance) or stat/weapon otherwise
+        if passive_pool and random.random() < passive_chance:
             _take(passive_pool) or _take(stat_pool) or _take(weapon_pool)
         else:
             _take(stat_pool) or _take(weapon_pool) or _take(passive_pool)
 
-        # Slot 3 — fill from anything still available (passives excluded when full)
+        # Slot 3 — fill from remaining; when full, only allow a passive if neither
+        # of the first two slots already has one (cap at 1 passive per screen when full)
+        already_has_passive = any(c.get("effect") == "passive" for c in chosen)
         remaining = [e for e in pool
                      if id(e) not in chosen_ids
-                     and (e.get("effect") != "passive" or not self._passives_full)]
+                     and (e.get("effect") != "passive"
+                          or not self._passives_full
+                          or not already_has_passive)]
         if remaining:
             chosen.append(random.choice(remaining))
 

--- a/src/ui/levelup.py
+++ b/src/ui/levelup.py
@@ -242,8 +242,50 @@ class LevelUpScreen:
                     "desc": w["desc"],
                 })
 
-        # Pick 3
-        self.choices = random.sample(pool, min(3, len(pool)))
+        # ── Weighted 3-choice selection ──────────────────────────────────────
+        # Separate pool into categories for intentional representation.
+        # When passive slots are full: no passive offers (stops swap-screen spam).
+        stat_pool    = [e for e in pool
+                        if e.get("type") == "stat" and e.get("effect") != "passive"]
+        passive_pool = ([] if self._passives_full
+                        else [e for e in pool if e.get("effect") == "passive"])
+        weapon_pool  = [e for e in pool
+                        if e.get("type") in ("weapon", "weapon_upgrade")]
+
+        chosen: list[dict] = []
+        chosen_ids: set[int] = set()
+
+        def _take(src: list) -> bool:
+            """Pick a random unused entry from src. Returns True on success."""
+            candidates = [e for e in src if id(e) not in chosen_ids]
+            if not candidates:
+                return False
+            pick = random.choice(candidates)
+            chosen_ids.add(id(pick))
+            chosen.append(pick)
+            return True
+
+        # Slot 1 — weapon upgrade or stat (weapons weighted 60 : 40)
+        if weapon_pool and random.random() < 0.60:
+            _take(weapon_pool) or _take(stat_pool)
+        else:
+            _take(stat_pool) or _take(weapon_pool)
+
+        # Slot 2 — passive if available (55% chance) or stat/weapon otherwise
+        if passive_pool and random.random() < 0.55:
+            _take(passive_pool) or _take(stat_pool) or _take(weapon_pool)
+        else:
+            _take(stat_pool) or _take(weapon_pool) or _take(passive_pool)
+
+        # Slot 3 — fill from anything still available (passives excluded when full)
+        remaining = [e for e in pool
+                     if id(e) not in chosen_ids
+                     and (e.get("effect") != "passive" or not self._passives_full)]
+        if remaining:
+            chosen.append(random.choice(remaining))
+
+        random.shuffle(chosen)
+        self.choices = chosen
 
     def handle_event(self, event: pygame.event.Event) -> dict | None:
         """Returns the chosen upgrade dict, or None if still choosing."""

--- a/src/ui/main_menu.py
+++ b/src/ui/main_menu.py
@@ -237,6 +237,18 @@ class MainMenuScreen:
         sub = self.font_sub.render("cyber. survive. repeat.", True, (100, 120, 160))
         surface.blit(sub, (SCREEN_WIDTH // 2 - sub.get_width() // 2, 210))
 
+        # Early Access badge
+        pulse = 0.85 + 0.15 * math.sin(now * 0.003)
+        badge_surf = self.font_small.render("\u2605  EARLY ACCESS  \u2605", True, (18, 12, 4))
+        bw = badge_surf.get_width() + 22
+        bh = badge_surf.get_height() + 8
+        bx = SCREEN_WIDTH // 2 - bw // 2
+        by = 240
+        badge_color = (int(215 * pulse), int(155 * pulse), int(25 * pulse))
+        pygame.draw.rect(surface, badge_color, (bx, by, bw, bh), border_radius=5)
+        pygame.draw.rect(surface, (255, 215, 70), (bx, by, bw, bh), 1, border_radius=5)
+        surface.blit(badge_surf, (bx + 11, by + 4))
+
         if self.settings_open:
             self._draw_settings(surface, now)
         else:
@@ -265,6 +277,12 @@ class MainMenuScreen:
                 surface.blit(bar, (x - 20, y - 4))
 
             surface.blit(text, (x, y))
+
+        # Early Access disclaimer
+        disc = self.font_small.render(
+            "Early Access: breaking changes & leaderboard resets may occur  \u2014  thank you for your support!",
+            True, (95, 85, 65))
+        surface.blit(disc, (SCREEN_WIDTH // 2 - disc.get_width() // 2, 562))
 
         # Controls hint
         hint = self.font_small.render("W/S to navigate  |  E/Enter to select", True, (70, 70, 90))


### PR DESCRIPTION
## Summary

Four feature additions and one crash fix across the `refactor/appdata-and-polish` branch.

---

### ⚔️ Knight Passive Shield Block
- Shield graphic drawn on knight's left arm (kite shape, steel-blue with trim)
- **28% chance** to passively block incoming bullets — blocked bullets removed with no damage
- **Plink SFX** plays on block + 5 hit sparks spawn at the blocked bullet's position
- `_make_plink()`: short 120ms metallic high-frequency ring

### 🥔 Spud Gun (Jester weapon #7)
- Weapon stats: 1.6× dmg, 480ms cooldown, speed 8.5, 850ms lifetime
- Fires potato projectiles — brown tumbling oval with highlight & shadow dot (`_draw_potato`)
- **Thump SFX**: 180ms hollow wobbling low-frequency launch (`_make_thump`)
- Upgrades: *Starch Rounds* (+11 dmg), *Spud Salvo* (−65ms cooldown)
- Custom icon: barrel + potato lump with eyes (`_wi_spud_gun`)

### 🗡️ Weapon Roster Cleanup
- Rename `"axe"` dict key → `"battle_axe"` (display name was already "Battle Axe")
- Remove `hammer` from knight weapon pool (redundant slot freed)
- Changes propagated to weapons, levelup, icons

### 🎮 Early Access UI (Main Menu)
- Pulsing amber **★ EARLY ACCESS ★** badge centred below the subtitle
- Disclaimer line: *"Early Access: breaking changes & leaderboard resets may occur — thank you for your support!"*

### 🐛 Fix: Super Skill Crash (all classes)
- `_sf_alpha` (super flash overlay) was computed as 360+ on the first draw frame, crashing `pygame.Surface.fill()` with `"invalid color argument"`
- Fix: clamp with `min(255, ...)` — alpha now correctly holds at 255 during the hold phase and fades over 250ms

---

### System changes (bundled from prior session)
- Energy system: max 120, 12-pip HUD bar, 10/kill 60/boss
- Status effects: `blue_fire`, `shock`, `freeze`, `insanity`
- Weapon `on_hit_status`: plasma_blade→fire, joy_buzzer→shock, pie_launcher→poison
- Passives: Burning Strikes, Toxic Strikes
- Knight super: Infernal Cleave (160° arc, blue_fire DoT)
- Archer super: Storm Barrage (5 explosive bolts ×40 dmg)
- Jester super: Chaos Eruption (12+6 grenades ×16/×10 dmg)
- Arc sweep particle animation (`spawn_arc_sweep`)