### PR TITLE
fix: commit public Supabase anon key + bundle in PyInstaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,3 @@ profile.json
 
 # Screenshots taken in-game (F9)
 screenshots/
-
-# Local secrets — NEVER commit this file
-src/secrets.py

--- a/cyber_survivor.spec
+++ b/cyber_survivor.spec
@@ -23,6 +23,8 @@ a = Analysis(
         'pygame',
         'pygame.mixer',
         'pygame.sndarray',
+        # Created at CI build time — PyInstaller may miss try/except import
+        'src.secrets',
     ],
     hookspath=[],
     hooksconfig={},

--- a/src/game.py
+++ b/src/game.py
@@ -88,7 +88,7 @@ class Game:
         self._game_over_start_time = 0
         # Profile — always present; create a local one if none was passed
         self.profile: PlayerProfile = profile or create_profile()
-        self.main_menu = MainMenuScreen()
+        self.main_menu = MainMenuScreen(display_name=self.profile.display_name)
         self.char_select = CharacterSelectScreen()
         self.char_class = None  # set after selection
         self.run_summary = RunSummaryScreen()
@@ -132,6 +132,7 @@ class Game:
         # Show name entry screen on first launch (runs synchronously before main loop)
         if self.profile.needs_name():
             self._run_name_entry_sync()
+            self.main_menu.display_name = self.profile.display_name
 
         # Analytics / leaderboard
         self.telemetry = TelemetryClient(SUPABASE_URL, SUPABASE_ANON_KEY)
@@ -151,9 +152,10 @@ class Game:
 
     def _run_name_entry_sync(self):
         """Block until the player has typed and confirmed a display name.
-        Called from __init__ on first launch before the main async loop."""
+        Called from __init__ on first launch before the main async loop,
+        and from the main menu 'Change Name' option."""
         name_entry = NameEntryScreen()
-        name_entry.activate()
+        name_entry.activate(suggested=self.profile.display_name)
         clock = pygame.time.Clock()
         while name_entry.active:
             dt = clock.tick(60)
@@ -367,6 +369,9 @@ class Game:
                         self.compendium_screen.activate()
                     elif result == "leaderboard":
                         self.leaderboard_screen.activate(self.profile.player_id)
+                    elif result == "change_name":
+                        self._run_name_entry_sync()
+                        self.main_menu.display_name = self.profile.display_name
                     elif result == "debug_menu":
                         self.debug_menu.active = True
                     elif result == "quit":

--- a/src/secrets.py
+++ b/src/secrets.py
@@ -1,10 +1,5 @@
-# src/secrets.py — LOCAL ONLY, never committed
-# Fill in your values then save. Ask Copilot to run when ready.
+# src/secrets.py — Public client keys for backend services
 #
-# Supabase → Project Settings → API
+# Supabase → Project Settings → API  (anon key is safe for public repos)
 SUPABASE_URL      = "https://vrhdbtphzvjfmtjjiirb.supabase.co"
 SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZyaGRidHBoenZqZm10amppaXJiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUzMTQwNjQsImV4cCI6MjA5MDg5MDA2NH0.pSo1gexun9zTMkgAlBbD7WSCDxoUim7zreOw848sjJE"
-
-# itch.io slug (the part after your username in the game URL)
-ITCH_GAME_SLUG = "cyber-survivor"
-ITCH_USERNAME  = "tylertech"

--- a/src/secrets.py
+++ b/src/secrets.py
@@ -1,0 +1,10 @@
+# src/secrets.py — LOCAL ONLY, never committed
+# Fill in your values then save. Ask Copilot to run when ready.
+#
+# Supabase → Project Settings → API
+SUPABASE_URL      = "https://vrhdbtphzvjfmtjjiirb.supabase.co"
+SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZyaGRidHBoenZqZm10amppaXJiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUzMTQwNjQsImV4cCI6MjA5MDg5MDA2NH0.pSo1gexun9zTMkgAlBbD7WSCDxoUim7zreOw848sjJE"
+
+# itch.io slug (the part after your username in the game URL)
+ITCH_GAME_SLUG = "cyber-survivor"
+ITCH_USERNAME  = "tylertech"

--- a/src/settings.py
+++ b/src/settings.py
@@ -8,7 +8,7 @@ NATIVE_HEIGHT = 0  # filled in by main.py
 RESOLUTIONS: dict = {}  # filled in by main.py
 FPS = 60
 TITLE = "Cyber Survivor"
-VERSION = "0.9.6"
+VERSION = "0.9.7"
 
 # -- User data directory (%APPDATA%/CyberSurvivor on Windows) --
 import os as _os

--- a/src/ui/main_menu.py
+++ b/src/ui/main_menu.py
@@ -43,10 +43,11 @@ def save_settings(settings: dict):
 class MainMenuScreen:
     """Title screen with menu options."""
 
-    def __init__(self):
+    def __init__(self, display_name: str = ""):
         self.active = True
         self.selected = 0
-        self.options = ["New Run", "Compendium", "Leaderboard", "Settings", "Quit"]
+        self.display_name = display_name
+        self.options = ["New Run", "Compendium", "Leaderboard", "Change Name", "Settings", "Quit"]
         self.settings_open = False
         self.settings_selected = 0
         self.settings = load_settings()
@@ -137,6 +138,8 @@ class MainMenuScreen:
                             return "compendium"
                         elif opt == "Leaderboard":
                             return "leaderboard"
+                        elif opt == "Change Name":
+                            return "change_name"
                         elif opt == "Settings":
                             self.settings_open = True
                             self.settings_selected = 0
@@ -167,6 +170,8 @@ class MainMenuScreen:
                 return "compendium"
             elif opt == "Leaderboard":
                 return "leaderboard"
+            elif opt == "Change Name":
+                return "change_name"
             elif opt == "Settings":
                 self.settings_open = True
                 self.settings_selected = 0
@@ -265,7 +270,11 @@ class MainMenuScreen:
             color = YELLOW if is_sel else (140, 140, 160)
             prefix = "> " if is_sel else "  "
 
-            text = self.font.render(f"{prefix}{opt}", True, color)
+            label = opt
+            if opt == "Change Name" and self.display_name:
+                label = f"Change Name  ({self.display_name})"
+
+            text = self.font.render(f"{prefix}{label}", True, color)
             x = SCREEN_WIDTH // 2 - text.get_width() // 2
             y = start_y + i * 50
 


### PR DESCRIPTION
## Problem
The leaderboard shows "not configured" in CI-built releases because `src/secrets.py` was gitignored and the GitHub Actions secrets injection was unreliable.

## Fix
- **Remove `src/secrets.py` from `.gitignore`** — the Supabase anon key is a public client-side key (safe to commit, same as what would be visible in browser network requests)
- **Add `src.secrets` to `hiddenimports`** in `cyber_survivor.spec` so PyInstaller always bundles it in frozen builds

This ensures every build (local and CI) gets a working leaderboard without needing GitHub Actions secrets for Supabase.